### PR TITLE
Test: Express runtime, reports, and Drive upload hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Network Scanner GUI - A web-based network scanning and monitoring tool powered b
 ## Quick Start
 
 ```bash
-git clone https://github.com/techmore/NMapUI-www.git
-cd NMapUI-www
+git clone https://github.com/techmore/TM-NmapUI.git
+cd TM-NmapUI
 ./install.sh
-sudo node server.js
+sudo npm start
 ```
 
 Then open http://localhost:9000 in your browser.
@@ -44,7 +44,7 @@ All dependencies are installed automatically by `install.sh`.
 ### Start the server
 
 ```bash
-sudo node server.js
+sudo npm start
 ```
 
 The server runs on port 9000 by default. Access at http://localhost:9000

--- a/google_drive.py
+++ b/google_drive.py
@@ -515,6 +515,7 @@ def ensure_google_drive_reports_folder(
     key_path: Path | None = None,
     requests_module,
     folder_name: str = "nmapui-reports",
+    parent_id: str | None = None,
 ) -> dict:
     access_token = ensure_google_drive_access_token(
         credentials_path=credentials_path,
@@ -523,15 +524,20 @@ def ensure_google_drive_reports_folder(
         requests_module=requests_module,
     )
     headers = {"Authorization": f"Bearer {access_token}"}
-    query = (
-        "mimeType='application/vnd.google-apps.folder' "
-        f"and name='{folder_name}' and trashed=false"
-    )
+    escaped_name = folder_name.replace("\\", "\\\\").replace("'", "\\'")
+    query_parts = [
+        "mimeType='application/vnd.google-apps.folder'",
+        f"name='{escaped_name}'",
+        "trashed=false",
+    ]
+    if parent_id:
+        query_parts.append(f"'{parent_id}' in parents")
+    query = " and ".join(query_parts)
     try:
         response = requests_module.get(
             GOOGLE_DRIVE_FILES_ENDPOINT,
             headers=headers,
-            params={"q": query, "fields": "files(id,name)"},
+            params={"q": query, "fields": "files(id,name,webViewLink)"},
             timeout=10,
         )
     except Exception as exc:
@@ -547,13 +553,17 @@ def ensure_google_drive_reports_folder(
     files = payload.get("files") or []
     if files:
         folder_id = files[0].get("id")
-        return {"success": True, "folder_id": folder_id, "status": "Drive folder ready"}
+        return {"success": True, "folder_id": folder_id, "folder": files[0], "status": "Drive folder ready"}
 
     try:
         create_response = requests_module.post(
             GOOGLE_DRIVE_FILES_ENDPOINT,
             headers={**headers, "Content-Type": "application/json"},
-            json={"name": folder_name, "mimeType": GOOGLE_DRIVE_FOLDER_MIME},
+            json={
+                "name": folder_name,
+                "mimeType": GOOGLE_DRIVE_FOLDER_MIME,
+                **({"parents": [parent_id]} if parent_id else {}),
+            },
             timeout=10,
         )
     except Exception as exc:
@@ -568,6 +578,7 @@ def ensure_google_drive_reports_folder(
     return {
         "success": True,
         "folder_id": create_payload.get("id"),
+        "folder": create_payload,
         "status": "Drive folder created",
     }
 
@@ -639,6 +650,7 @@ def main() -> int:
     parser.add_argument("--state", default="")
     parser.add_argument("--folder-id", default="")
     parser.add_argument("--folder-name", default="Nmap Reports")
+    parser.add_argument("--day-folder-name", default="")
     parser.add_argument("--files", nargs="*", default=[])
     parser.add_argument("--credentials-json", default="")
     args = parser.parse_args()
@@ -677,13 +689,28 @@ def main() -> int:
                     _print_json(folder_result)
                     return 1
                 folder_id = folder_result.get("folder_id") or ""
+            upload_folder_id = folder_id
+            day_folder_id = ""
+            if args.day_folder_name:
+                day_folder_result = ensure_google_drive_reports_folder(
+                    folder_name=args.day_folder_name,
+                    parent_id=folder_id,
+                    requests_module=requests_module,
+                    **paths,
+                )
+                if not day_folder_result.get("success"):
+                    _print_json(day_folder_result)
+                    return 1
+                day_folder_id = day_folder_result.get("folder_id") or ""
+                upload_folder_id = day_folder_id
             result = upload_files_to_google_drive(
                 file_paths=[Path(file_path).resolve() for file_path in args.files],
-                folder_id=folder_id,
+                folder_id=upload_folder_id,
                 requests_module=requests_module,
                 **paths,
             )
             result["folder_id"] = folder_id
+            result["day_folder_id"] = day_folder_id
             _print_json(result)
             return 0
     except Exception as exc:

--- a/index.html
+++ b/index.html
@@ -1522,8 +1522,8 @@
         <table id="discovery-table" class="table-fixed min-w-[2400px]">
                         <thead>
                             <tr>
-                                <th class="w-16 px-1 py-0.5 text-left" data-column="status" data-fixed="true"></th>
-                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
+                                <th class="w-16 px-0 py-0.5 text-left" data-column="status" data-fixed="true"></th>
+                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>IP Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1536,7 +1536,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-40 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
+                                <th class="sortable w-40 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>MAC Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1549,7 +1549,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Vendor</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1562,7 +1562,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Hostname</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1575,7 +1575,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-80 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
+                                <th class="sortable w-80 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>CVEs</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1588,17 +1588,17 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
+                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>OS / Device</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
+                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>Latency</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
+                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Open Ports</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1611,7 +1611,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Version</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1624,7 +1624,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="w-32 px-1 py-0.5 text-left" data-column="actions" data-fixed="true">Actions</th>
+                                <th class="w-32 px-0 py-0.5 text-left" data-column="actions" data-fixed="true">Actions</th>
                             </tr>
                         </thead>
 

--- a/index.html
+++ b/index.html
@@ -1519,11 +1519,11 @@
     <!-- Results Table -->
     <section id="dashboard-results-panel" class="page-shell">
         <div class="results-band">
-        <table id="discovery-table" class="table-fixed min-w-[2400px]">
+        <table id="discovery-table" class="table-fixed min-w-[1480px]">
                         <thead>
                             <tr>
-                                <th class="w-16 px-0 py-0.5 text-left" data-column="status" data-fixed="true"></th>
-                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
+                                <th class="w-8 px-0 py-0.5 text-left" data-column="status" data-fixed="true"></th>
+                                <th class="sortable w-24 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>IP Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1536,7 +1536,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-40 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
+                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>MAC Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1549,7 +1549,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-24 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Vendor</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1562,7 +1562,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-28 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Hostname</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1575,7 +1575,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-80 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
+                                <th class="sortable w-56 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>CVEs</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1588,17 +1588,17 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
+                                <th class="sortable w-48 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>OS / Device</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
+                                <th class="sortable w-24 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>Latency</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
+                                <th class="sortable w-48 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Open Ports</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1611,7 +1611,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-56 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Version</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1624,7 +1624,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="w-32 px-0 py-0.5 text-left" data-column="actions" data-fixed="true">Actions</th>
+                                <th class="w-20 px-0 py-0.5 text-left" data-column="actions" data-fixed="true">Actions</th>
                             </tr>
                         </thead>
 

--- a/index.html
+++ b/index.html
@@ -1522,8 +1522,8 @@
         <table id="discovery-table" class="table-fixed min-w-[2400px]">
                         <thead>
                             <tr>
-                                <th class="w-16 px-2 py-1.5 text-left" data-column="status" data-fixed="true"></th>
-                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
+                                <th class="w-16 px-1 py-0.5 text-left" data-column="status" data-fixed="true"></th>
+                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>IP Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1536,7 +1536,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-40 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
+                                <th class="sortable w-40 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>MAC Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1549,7 +1549,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Vendor</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1562,7 +1562,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Hostname</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1575,7 +1575,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-80 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
+                                <th class="sortable w-80 px-0.5 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>CVEs</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1588,17 +1588,17 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
+                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>OS / Device</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
+                                <th class="sortable w-32 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>Latency</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
+                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Open Ports</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1611,7 +1611,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-64 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Version</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1624,7 +1624,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="w-32 px-2 py-1.5 text-left" data-column="actions" data-fixed="true">Actions</th>
+                                <th class="w-32 px-1 py-0.5 text-left" data-column="actions" data-fixed="true">Actions</th>
                             </tr>
                         </thead>
 

--- a/index.html
+++ b/index.html
@@ -279,6 +279,7 @@
     }
 
     .results-band {
+        width: 100%;
         margin-top: 2rem;
         border-radius: 0.75rem;
         border: 1px solid oklch(75% 0.040 110);
@@ -290,8 +291,38 @@
 
     #discovery-table {
         width: 100%;
-        min-width: 1180px;
+        min-width: 100%;
     }
+
+    #discovery-table th,
+    #discovery-table td {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    #discovery-table th:nth-child(1),
+    #discovery-table td:nth-child(1) { width: 3%; }
+    #discovery-table th:nth-child(2),
+    #discovery-table td:nth-child(2) { width: 12%; }
+    #discovery-table th:nth-child(3),
+    #discovery-table td:nth-child(3) { width: 16%; }
+    #discovery-table th:nth-child(4),
+    #discovery-table td:nth-child(4) { width: 9%; }
+    #discovery-table th:nth-child(5),
+    #discovery-table td:nth-child(5) { width: 11%; }
+    #discovery-table th:nth-child(6),
+    #discovery-table td:nth-child(6) { width: 12%; }
+    #discovery-table th:nth-child(7),
+    #discovery-table td:nth-child(7) { width: 10%; }
+    #discovery-table th:nth-child(8),
+    #discovery-table td:nth-child(8) { width: 6%; }
+    #discovery-table th:nth-child(9),
+    #discovery-table td:nth-child(9) { width: 7%; }
+    #discovery-table th:nth-child(10),
+    #discovery-table td:nth-child(10) { width: 9%; }
+    #discovery-table th:nth-child(11),
+    #discovery-table td:nth-child(11) { width: 5%; }
 
     .modal-overlay {
         position: fixed;
@@ -1528,7 +1559,7 @@
                         <thead>
                             <tr>
                                 <th class="w-8 px-0 py-0.5 text-left" data-column="status" data-fixed="true"></th>
-                                <th class="sortable w-24 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
+                                <th class="sortable w-24 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>IP Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1541,7 +1572,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-0 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
+                                <th class="sortable w-32 px-1 py-0.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>MAC Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Network Scanner GUI</title>
+    <title>TM-NMAPUI</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet" />
@@ -422,7 +422,7 @@
         <div class="flex items-center gap-6">
             <img src="static/techmore.png" class="h-12 w-auto">
             <div>
-                <h1 class="text-4xl font-display italic text-olive-950">Network Scanner</h1>
+                <h1 class="text-4xl font-display italic text-olive-950">TM-NMAPUI</h1>
                 <div class="flex items-center gap-2">
                     <div id="app-version" class="text-sm text-olive-600 font-medium">v2026.4.26.4.00</div>
                     <a

--- a/index.html
+++ b/index.html
@@ -621,7 +621,7 @@
         </div>
         <div id="reports-tab-status" class="mt-4 hidden rounded-xl bg-olive-50 px-4 py-3 text-sm text-olive-800"></div>
         <div id="reports-customer-filters" class="mt-4 flex flex-wrap gap-2"></div>
-        <div id="reports-tab-list" class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3"></div>
+        <div id="reports-tab-list" class="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4"></div>
     </section>
 
     <section id="customers-tab-panel" class="hidden rounded-3xl border border-olive-200 bg-white/80 p-6 shadow-sm backdrop-blur">

--- a/index.html
+++ b/index.html
@@ -1354,6 +1354,10 @@
                 <div id="last-scan-duration" class="text-center text-[10px] text-olive-500 font-bold uppercase tracking-widest hidden">
                     Last Duration: <span id="last-scan-time-val">--</span>
                 </div>
+                <label class="flex items-center justify-center gap-2 text-[10px] font-bold uppercase tracking-widest text-olive-500 cursor-pointer">
+                    <input type="checkbox" id="vpn-helper-toggle" class="size-4 rounded border-olive-300 text-olive-700 focus:ring-olive-500" aria-label="Enable VPN helper scan mode">
+                    <span>VPN Helper</span>
+                </label>
             </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -288,6 +288,11 @@
         overflow-x: auto;
     }
 
+    #discovery-table {
+        width: 100%;
+        min-width: 1180px;
+    }
+
     .modal-overlay {
         position: fixed;
         inset: 0;
@@ -1519,7 +1524,7 @@
     <!-- Results Table -->
     <section id="dashboard-results-panel" class="page-shell">
         <div class="results-band">
-        <table id="discovery-table" class="table-fixed min-w-[1480px]">
+        <table id="discovery-table" class="table-fixed">
                         <thead>
                             <tr>
                                 <th class="w-8 px-0 py-0.5 text-left" data-column="status" data-fixed="true"></th>

--- a/index.html
+++ b/index.html
@@ -1522,8 +1522,8 @@
         <table id="discovery-table" class="table-fixed min-w-[2400px]">
                         <thead>
                             <tr>
-                                <th class="w-16 px-4 py-3 text-left" data-column="status" data-fixed="true"></th>
-                                <th class="sortable w-32 px-1.5 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
+                                <th class="w-16 px-2 py-1.5 text-left" data-column="status" data-fixed="true"></th>
+                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="ip" data-type="ip" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>IP Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1536,7 +1536,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-40 px-1.5 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
+                                <th class="sortable w-40 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="mac" data-type="mac" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>MAC Address</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1549,7 +1549,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-1.5 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="vendor" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Vendor</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1562,7 +1562,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-1.5 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-32 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="hostname" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Hostname</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1575,7 +1575,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-80 px-2 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
+                                <th class="sortable w-80 px-1 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="cves" data-type="number" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>CVEs</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1588,17 +1588,17 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-4 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
+                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="os" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>OS / Device</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-32 px-4 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
+                                <th class="sortable w-32 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="latency" data-type="text">
                                     <div class="flex items-center space-x-1">
                                         <span>Latency</span>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-4 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
+                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="open_ports" data-type="ports" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Open Ports</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1611,7 +1611,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="sortable w-64 px-4 py-3 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
+                                <th class="sortable w-64 px-2 py-1.5 text-left cursor-pointer hover:bg-olive-100 transition-colors group" data-column="version" data-type="text" title="Drag to reorder">
                                     <div class="flex items-center space-x-1">
                                         <span>Version</span>
                                         <div class="sort-indicators opacity-0 group-hover:opacity-100 transition-opacity">
@@ -1624,7 +1624,7 @@
                                         </div>
                                     </div>
                                 </th>
-                                <th class="w-32 px-4 py-3 text-left" data-column="actions" data-fixed="true">Actions</th>
+                                <th class="w-32 px-2 py-1.5 text-left" data-column="actions" data-fixed="true">Actions</th>
                             </tr>
                         </thead>
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "========================================"
 echo "TM-NMapUI - Dependency Installer"
 echo "========================================"
@@ -9,8 +12,11 @@ echo "========================================"
 BREW_PACKAGES=(
     "node"
     "nmap"
-    "wkhtmltopdf"
     "libxslt"
+)
+
+OPTIONAL_BREW_PACKAGES=(
+    "wkhtmltopdf"
 )
 
 echo ""
@@ -37,11 +43,26 @@ for pkg in "${BREW_PACKAGES[@]}"; do
     fi
 done
 
+for pkg in "${OPTIONAL_BREW_PACKAGES[@]}"; do
+    if brew list "$pkg" &> /dev/null; then
+        echo "$pkg already installed."
+    else
+        echo "Installing optional package $pkg..."
+        if ! brew install "$pkg"; then
+            echo "WARNING: optional package $pkg is unavailable. PDF export can still use Chromium/Chrome when installed."
+        fi
+    fi
+done
+
 echo ""
 echo "[4/5] Installing npm packages..."
 if [ -f "package.json" ]; then
     if command -v npm &> /dev/null; then
-        npm install
+        if [ -f "package-lock.json" ]; then
+            npm ci
+        else
+            npm install
+        fi
         echo "npm packages installed."
     else
         echo "ERROR: npm not found. Please install Node.js via Homebrew: brew install node"
@@ -59,7 +80,6 @@ verify_commands=(
     "nmap:nmap"
     "python3:python3"
     "xsltproc:xsltproc"
-    "wkhtmltopdf:wkhtmltopdf"
     "express:node"
 )
 
@@ -70,6 +90,8 @@ for cmd in "${verify_commands[@]}"; do
     if [[ "$BINARY" == "express" ]]; then
         if ! node -e "require('express')" &> /dev/null; then
             echo "MISSING: express"
+            echo "Expected Express under: $(npm root 2>/dev/null || echo "$SCRIPT_DIR/node_modules")"
+            echo "Try re-running ./install.sh from $SCRIPT_DIR"
             MISSING=1
         else
             echo "OK: express - installed"
@@ -87,7 +109,7 @@ echo ""
 echo "========================================"
 if [ $MISSING -eq 0 ]; then
     echo "Installation complete!"
-    echo "Run 'npm start' to start the application."
+    echo "Run 'sudo npm start' to start the application."
 else
     echo "Some dependencies are missing."
     echo "Please restart your terminal and re-run this script."

--- a/nmap-modern.xsl
+++ b/nmap-modern.xsl
@@ -772,7 +772,7 @@ Updated: 2026
 	            }
 
 	            @page {
-	              size: Letter landscape;
+	              size: Letter portrait;
 	              margin: 3mm;
 	            }
           }

--- a/server.js
+++ b/server.js
@@ -328,6 +328,7 @@ function generatePDF(reportPath, pdfPath, callback) {
             '--no-pdf-header-footer',
             '--run-all-compositor-stages-before-draw',
             '--virtual-time-budget=5000',
+            '--print-to-pdf-page-size=Letter',
             `--print-to-pdf=${shellQuote(pdfPath)}`,
             shellQuote(reportUrl)
         ].join(' ');

--- a/server.js
+++ b/server.js
@@ -819,10 +819,19 @@ function generateReportFromXml(socket, xmlPath, duration, reportScanKind) {
     const reportBaseName = `${profile.reportLabel}-${reportTimestamp}`;
     const reportName = `${reportBaseName}.html`;
     const pdfName = `${reportBaseName}.pdf`;
+    const xmlName = `${reportBaseName}.xml`;
     const reportPath = path.join(reportDir, reportName);
     const pdfPath = path.join(reportDir, pdfName);
+    const xmlArchivePath = path.join(reportDir, xmlName);
     const reportUrl = `/reports/${profile.folderName}/${reportName}`;
     const pdfUrl = `/reports/${profile.folderName}/${pdfName}`;
+    const xmlUrl = `/reports/${profile.folderName}/${xmlName}`;
+    try {
+        fs.copyFileSync(xmlPath, xmlArchivePath);
+        logEvent(socket, 'report', `XML archived: ${xmlName}`);
+    } catch (error) {
+        logEvent(socket, 'error', `XML archive failed for ${xmlName}: ${error.message}`);
+    }
     const xslPath = path.join(__dirname, 'nmap-modern.xsl');
     const xsltCommand = [
         'xsltproc',
@@ -848,6 +857,8 @@ function generateReportFromXml(socket, xmlPath, duration, reportScanKind) {
                     pdfUrl: pdfReady ? pdfUrl : null,
                     name: reportName,
                     pdfName: pdfReady ? pdfName : null,
+                    xmlName,
+                    xmlUrl: fs.existsSync(xmlArchivePath) ? xmlUrl : null,
                     customerProfile: profile
                 };
                 io.emit('report_ready', reportPayload);
@@ -859,6 +870,7 @@ function generateReportFromXml(socket, xmlPath, duration, reportScanKind) {
                     hostCount: discoveredHosts.length,
                     reportUrl,
                     pdfUrl: pdfReady ? pdfUrl : null,
+                    xmlUrl: fs.existsSync(xmlArchivePath) ? xmlUrl : null,
                     customerProfile: profile
                 });
                 saveJSON(HISTORY_PATH, history.slice(0, 50));
@@ -1304,8 +1316,10 @@ io.on('connection', (socket) => {
                     : [entry.name];
                 files.forEach(f => {
                     const pdfName = f.replace(/\.html$/i, '.pdf');
+                    const xmlName = f.replace(/\.html$/i, '.xml');
                     const reportPath = path.join(folderPath, f);
                     const pdfPath = path.join(folderPath, pdfName);
+                    const xmlPath = path.join(folderPath, xmlName);
                     const driveMetadata = loadDriveMetadata(reportPath);
                     const urlBase = folder ? `/reports/${folder}` : '/reports';
                     reports.push({
@@ -1314,6 +1328,8 @@ io.on('connection', (socket) => {
                         url: `${urlBase}/${f}`,
                         pdfName: fs.existsSync(pdfPath) ? pdfName : null,
                         pdfUrl: fs.existsSync(pdfPath) ? `${urlBase}/${pdfName}` : null,
+                        xmlName: fs.existsSync(xmlPath) ? xmlName : null,
+                        xmlUrl: fs.existsSync(xmlPath) ? `${urlBase}/${xmlName}` : null,
                         driveHtmlUrl: findDriveLink(driveMetadata, f),
                         drivePdfUrl: fs.existsSync(pdfPath) ? findDriveLink(driveMetadata, pdfName) : null,
                         date: fs.statSync(reportPath).mtime

--- a/server.js
+++ b/server.js
@@ -56,6 +56,20 @@ const CONFIG_PATH = path.join(__dirname, 'config.json');
 const HISTORY_PATH = path.join(__dirname, 'history.json');
 const REPORTS_DIR = path.join(__dirname, 'reports_archive');
 const PHASE2_MAX_HOSTGROUP = String(Math.max(1, parseInt(process.env.NMAP_MAX_HOSTGROUP || '4', 10) || 4));
+const NMAP_PATH = resolveExecutable(process.env.NMAP_PATH, [
+    '/opt/homebrew/bin/nmap',
+    '/usr/local/bin/nmap',
+    '/usr/bin/nmap',
+    '/bin/nmap',
+    'nmap'
+]);
+const TRACEROUTE_PATH = resolveExecutable(process.env.TRACEROUTE_PATH, [
+    '/usr/sbin/traceroute',
+    '/sbin/traceroute',
+    '/opt/homebrew/bin/traceroute',
+    '/usr/local/bin/traceroute',
+    'traceroute'
+]);
 let customerProfileConfig = loadJSON(CONFIG_PATH, {}).customerProfile || {};
 let appConfig = loadJSON(CONFIG_PATH, {});
 
@@ -99,6 +113,41 @@ function saveAutoScanConfig(autoScanConfig) {
 
 function getGoogleDriveConfig() {
     return appConfig.googleDrive || {};
+}
+
+function isExecutable(filePath) {
+    if (!filePath) return false;
+    try {
+        fs.accessSync(filePath, fs.constants.X_OK);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function resolveExecutable(explicitPath, candidates) {
+    const searchPaths = (process.env.PATH || '')
+        .split(path.delimiter)
+        .filter(Boolean);
+    const pathCandidates = candidates
+        .filter(candidate => !candidate.includes(path.sep))
+        .flatMap(name => searchPaths.map(dir => path.join(dir, name)));
+    return [explicitPath, ...candidates, ...pathCandidates].find(isExecutable) || null;
+}
+
+function getPrivilegedCommand(executablePath, args) {
+    if (process.getuid && process.getuid() === 0) {
+        return { command: executablePath, args };
+    }
+    return { command: 'sudo', args: ['-n', executablePath, ...args] };
+}
+
+function describeMissingExecutable(name, envVar) {
+    return `${name} was not found. Install it or set ${envVar} to the executable path.`;
+}
+
+function isSudoAuthFailure(text) {
+    return /sudo:.*password|a password is required|no tty present|permission denied/i.test(text || '');
 }
 
 function shellQuote(value) {
@@ -422,9 +471,13 @@ async function getPublicIP() {
 
 function runTraceroute() {
     if (isTracerouteRunning) return;
+    if (!TRACEROUTE_PATH) {
+        console.warn(describeMissingExecutable('traceroute', 'TRACEROUTE_PATH'));
+        return;
+    }
     isTracerouteRunning = true;
     cachedHops = [];
-    const traceroute = spawn('traceroute', ['-m', '15', '-n', '-q', '1', '8.8.8.8']);
+    const traceroute = spawn(TRACEROUTE_PATH, ['-m', '15', '-n', '-q', '1', '8.8.8.8']);
     traceroute.stdout.on('data', (data) => {
         const lines = data.toString().split('\n');
         lines.forEach(line => {
@@ -437,6 +490,10 @@ function runTraceroute() {
                 }
             }
         });
+    });
+    traceroute.on('error', error => {
+        console.error(`[TRACEROUTE ERROR] ${error.message}`);
+        isTracerouteRunning = false;
     });
     traceroute.on('close', () => { isTracerouteRunning = false; });
 }
@@ -536,6 +593,10 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
         if (socket) logEvent(socket, 'error', 'A scan is already running.');
         return;
     }
+    if (!NMAP_PATH) {
+        logEvent(socket, 'error', describeMissingExecutable('nmap', 'NMAP_PATH'));
+        return;
+    }
 
     if (phase === 1) {
         discoveredHosts = [];
@@ -552,10 +613,11 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
     io.emit('scan_started', { phase, target: currentTarget, startTime: scanStartTime, scanKind: currentScanKind });
     logEvent(socket, 'job', `Starting Phase ${phase} scan...`);
     if (phase >= 2) {
-        logEvent(socket, 'scan', `Nmap command: sudo nmap ${args.join(' ')}`);
+        logEvent(socket, 'scan', `Nmap command: sudo -n ${NMAP_PATH} ${args.join(' ')}`);
     }
-    
-    const nmap = spawn('sudo', ['nmap', ...args]);
+
+    const commandSpec = getPrivilegedCommand(NMAP_PATH, args);
+    const nmap = spawn(commandSpec.command, commandSpec.args);
     currentScan = nmap;
 
     let currentHostIP = null;
@@ -598,6 +660,14 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
     nmap.stderr.on('data', (data) => {
         const errText = data.toString();
         if (!errText.includes('Warning: ')) console.error('[NMAP ERROR]', errText);
+        if (isSudoAuthFailure(errText)) {
+            logEvent(socket, 'error', 'Nmap requires passwordless sudo for this runtime. Configure sudoers for nmap or run with the required privileges.');
+        }
+    });
+
+    nmap.on('error', error => {
+        currentScan = null;
+        logEvent(socket, 'error', `Failed to start Nmap: ${error.message}`);
     });
 
     nmap.on('close', (code, signal) => {
@@ -799,6 +869,7 @@ io.on('connection', (socket) => {
         const network = cachedNetworkInfo || await getNetworkInfo();
         const publicIP = cachedPublicIP || await getPublicIP();
         socket.emit('initial_data', { ...network, publicIP, customerProfile: getCustomerFingerprintProfile(), googleDrive: appConfig.googleDrive || {}, autoScan: appConfig.autoScan || {} });
+        if (cachedHops.length === 0 && !isTracerouteRunning) runTraceroute();
         cachedHops.forEach(hop => socket.emit('traceroute_hop', hop));
     });
     socket.on('start_quick_scan', (data) => startChainedScan(socket, data.target, false));
@@ -893,8 +964,22 @@ io.on('connection', (socket) => {
 });
 
 // Initialization
-console.log('Prescan - Updating scripts...');
-exec('sudo nmap --script-updatedb');
+if (NMAP_PATH) {
+    console.log('Prescan - Updating scripts...');
+    const updateCommand = getPrivilegedCommand(NMAP_PATH, ['--script-updatedb']);
+    const updateProcess = spawn(updateCommand.command, updateCommand.args);
+    updateProcess.stderr.on('data', data => {
+        const text = data.toString();
+        if (isSudoAuthFailure(text)) {
+            console.warn('Skipping nmap script update: passwordless sudo is required.');
+        } else if (!text.includes('Warning: ')) {
+            console.warn(`[NMAP UPDATE] ${text.trim()}`);
+        }
+    });
+    updateProcess.on('error', error => console.warn(`Skipping nmap script update: ${error.message}`));
+} else {
+    console.warn(describeMissingExecutable('nmap', 'NMAP_PATH'));
+}
 
 setupAutoScan(loadJSON(CONFIG_PATH, {}));
 getNetworkInfo(); getPublicIP(); runTraceroute();

--- a/server.js
+++ b/server.js
@@ -461,7 +461,7 @@ function buildPhase2Args(usePn = false, fullPortScan = false, options = {}) {
     const hostGroupArgs = options.allHostsAtOnce
         ? []
         : ['--min-hostgroup', '1', '--max-hostgroup', PHASE2_MAX_HOSTGROUP];
-    const scripts = options.consolidateScripts ? ['default,vulners'] : ['vulners'];
+    const scripts = options.disableScripts ? [] : (options.consolidateScripts ? ['default,vulners'] : ['vulners']);
     const rateArgs = options.minRate === false ? [] : ['--min-rate', options.minRate || '3000'];
     const defaultScriptArgs = options.includeDefaultScripts === false || options.consolidateScripts ? [] : ['-sC'];
     const args = [
@@ -475,7 +475,7 @@ function buildPhase2Args(usePn = false, fullPortScan = false, options = {}) {
         ...(options.maxParallelism ? ['--max-parallelism', String(options.maxParallelism)] : []),
         ...hostGroupArgs,
         '--open',
-        '--script', scripts.join(','),
+        ...(scripts.length ? ['--script', scripts.join(',')] : []),
         '--stylesheet', 'nmap-modern.xsl',
         '-oX', 'phase2_results.xml',
         '-iL', 'targets.tmp'
@@ -797,6 +797,26 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
             const reportScanKind = options.scanKind || currentScanKind;
             setTimeout(() => {
                 if (!isCompleteNmapXML(xmlPath)) {
+                    if (options.retryWithoutVulners && !options.retriedWithoutVulners) {
+                        logEvent(socket, 'error', 'Phase 2 XML is incomplete after the vulners/NSE run. Retrying once without NSE scripts so a report can still be generated.');
+                        runNmap(
+                            socket,
+                            buildPhase2Args(true, false, {
+                                includeDefaultScripts: false,
+                                disableScripts: true,
+                                minRate: false,
+                                maxParallelism: 4
+                            }),
+                            phase,
+                            onComplete,
+                            {
+                                deferHostUpdates: true,
+                                scanKind: reportScanKind,
+                                retriedWithoutVulners: true
+                            }
+                        );
+                        return;
+                    }
                     logEvent(socket, 'error', 'Phase 2 XML is incomplete, likely because Nmap/NSE crashed. Skipping XML parse and report/PDF generation for this run.');
                     return;
                 }
@@ -971,17 +991,17 @@ function startChainedScan(socket, target, usePn = false) {
         fs.writeFileSync('targets.tmp', targets);
 
         if (usePn) {
-            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning all ${discoveredHosts.length} host(s) in one Nmap command with vulners. UI details will populate after XML parsing completes.`);
+            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning ${discoveredHosts.length} host(s) with bounded hostgroups to reduce NSE/vulners crashes. UI details will populate after XML parsing completes.`);
             runNmap(
                 socket,
                 buildPhase2Args(true, false, {
-                    allHostsAtOnce: true,
                     includeDefaultScripts: false,
-                    minRate: false
+                    minRate: false,
+                    maxParallelism: 4
                 }),
                 2,
                 null,
-                { deferHostUpdates: true, scanKind }
+                { deferHostUpdates: true, scanKind, retryWithoutVulners: true }
             );
             return;
         }

--- a/server.js
+++ b/server.js
@@ -558,6 +558,7 @@ function buildPhase2Args(usePn = false, fullPortScan = false, options = {}) {
         options.timing || '-T3',
         ...rateArgs,
         ...(options.maxParallelism ? ['--max-parallelism', String(options.maxParallelism)] : []),
+        ...(options.maxRetries ? ['--max-retries', String(options.maxRetries)] : []),
         ...hostGroupArgs,
         '--open',
         ...(scripts.length ? ['--script', scripts.join(',')] : []),
@@ -1203,7 +1204,7 @@ function getScanStats() {
     };
 }
 
-function startChainedScan(socket, target, usePn = false) {
+function startChainedScan(socket, target, usePn = false, options = {}) {
     const scanKind = usePn ? 'complete' : 'quick';
     runNmap(socket, ['-sn', '-T4', target], 1, () => {
         if (discoveredHosts.length === 0) {
@@ -1214,13 +1215,24 @@ function startChainedScan(socket, target, usePn = false) {
         fs.writeFileSync('targets.tmp', targets);
 
         if (usePn) {
-            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning all ${discoveredHosts.length} host(s) in one Nmap command with vulners. UI details will populate after XML parsing completes.`);
-            runNmap(
-                socket,
-                buildPhase2Args(true, false, {
+            const vpnHelper = !!options.vpnHelper;
+            const phase2Options = vpnHelper
+                ? {
+                    includeDefaultScripts: false,
+                    minRate: false,
+                    timing: '-T2',
+                    scriptArgs: 'mincvss=0,threads=5',
+                    maxParallelism: 15,
+                    maxRetries: 2
+                }
+                : {
                     includeDefaultScripts: false,
                     minRate: false
-                }),
+                };
+            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning all ${discoveredHosts.length} host(s) in one Nmap command with vulners${vpnHelper ? ' using VPN helper timing' : ''}. UI details will populate after XML parsing completes.`);
+            runNmap(
+                socket,
+                buildPhase2Args(true, false, phase2Options),
                 2,
                 null,
                 { deferHostUpdates: true, scanKind, fallbackOnIncomplete: true, deferScanComplete: true }
@@ -1242,7 +1254,7 @@ io.on('connection', (socket) => {
         cachedHops.forEach(hop => socket.emit('traceroute_hop', hop));
     });
     socket.on('start_quick_scan', (data) => startChainedScan(socket, data.target, false));
-    socket.on('start_complete_scan', (data) => startChainedScan(socket, data.target, true));
+    socket.on('start_complete_scan', (data) => startChainedScan(socket, data.target, true, { vpnHelper: !!data.vpnHelper }));
     socket.on('start_dragnet_scan', (data) => {
         if (discoveredHosts.length === 0) { logEvent(socket, 'error', 'No hosts discovered in Phase 1.'); return; }
         const targets = discoveredHosts.map(h => h.ip).join('\n');

--- a/server.js
+++ b/server.js
@@ -809,6 +809,183 @@ function parseNmapXML(xmlPath, onParsed = null) {
     });
 }
 
+function generateReportFromXml(socket, xmlPath, duration, reportScanKind) {
+    const profile = getCustomerFingerprintProfile();
+    const reportDir = path.join(REPORTS_DIR, profile.folderName);
+    if (!fs.existsSync(reportDir)) fs.mkdirSync(reportDir, { recursive: true });
+    const reportDate = new Date();
+    const reportTimestamp = formatReportTimestamp(reportDate);
+    const reportDisplayTimestamp = formatReportDisplayTimestamp(reportDate);
+    const reportBaseName = `${profile.reportLabel}-${reportTimestamp}`;
+    const reportName = `${reportBaseName}.html`;
+    const pdfName = `${reportBaseName}.pdf`;
+    const reportPath = path.join(reportDir, reportName);
+    const pdfPath = path.join(reportDir, pdfName);
+    const reportUrl = `/reports/${profile.folderName}/${reportName}`;
+    const pdfUrl = `/reports/${profile.folderName}/${pdfName}`;
+    const xslPath = path.join(__dirname, 'nmap-modern.xsl');
+    const xsltCommand = [
+        'xsltproc',
+        '-o', shellQuote(reportPath),
+        '--stringparam', 'customer_name', shellQuote(profile.prefix),
+        '--stringparam', 'report_identifier', shellQuote(profile.reportLabel),
+        '--stringparam', 'report_timestamp', shellQuote(reportTimestamp),
+        '--stringparam', 'report_display_timestamp', shellQuote(reportDisplayTimestamp),
+        '--stringparam', 'public_ip', shellQuote(profile.publicIP),
+        shellQuote(xslPath),
+        shellQuote(xmlPath)
+    ].join(' ');
+    exec(xsltCommand, (err) => {
+        if (!err) {
+            generatePDF(reportPath, pdfPath, (pdfErr) => {
+                const pdfReady = !pdfErr && fs.existsSync(pdfPath);
+                if (pdfErr) {
+                    logEvent(socket, 'error', `PDF generation failed for ${reportName}: ${pdfErr.message}`);
+                }
+                logEvent(socket, 'report', `Report generated: ${reportName}${pdfReady ? ` and ${pdfName}` : ''}`);
+                const reportPayload = {
+                    url: reportUrl,
+                    pdfUrl: pdfReady ? pdfUrl : null,
+                    name: reportName,
+                    pdfName: pdfReady ? pdfName : null,
+                    customerProfile: profile
+                };
+                io.emit('report_ready', reportPayload);
+                const history = loadJSON(HISTORY_PATH, []);
+                history.unshift({
+                    timestamp: new Date().toISOString(),
+                    target: currentTarget,
+                    duration,
+                    hostCount: discoveredHosts.length,
+                    reportUrl,
+                    pdfUrl: pdfReady ? pdfUrl : null,
+                    customerProfile: profile
+                });
+                saveJSON(HISTORY_PATH, history.slice(0, 50));
+                if (['complete', 'quick'].includes(reportScanKind)) {
+                    const uploadLabel = reportScanKind === 'quick' ? 'Quick Scan report' : 'Complete+PDF report';
+                    uploadReportFilesToDrive(socket, [reportPath, pdfReady ? pdfPath : null], profile, {
+                        label: uploadLabel,
+                        reportPath,
+                        dayFolderName: formatDriveDayFolder(reportDate)
+                    })
+                        .then(result => {
+                            if (!result?.success) return;
+                            const metadata = loadDriveMetadata(reportPath);
+                            io.emit('report_ready', {
+                                ...reportPayload,
+                                driveHtmlUrl: findDriveLink(metadata, reportName),
+                                drivePdfUrl: pdfReady ? findDriveLink(metadata, pdfName) : null
+                            });
+                        })
+                        .catch(error => logEvent(socket, 'error', `Google Drive upload failed for ${uploadLabel}: ${error.message}`));
+                }
+            });
+        } else {
+            logEvent(socket, 'error', `HTML report generation failed: ${err.message}`);
+        }
+    });
+}
+
+function runNmapFallbackPass(socket, args, phase, xmlFile, label, options = {}) {
+    return new Promise((resolve) => {
+        const startedAt = Date.now();
+        const commandSpec = getPrivilegedCommand(NMAP_PATH, args);
+        let stderrBuffer = '';
+
+        currentScanPhase = phase;
+        scanStartTime = startedAt;
+        io.emit('scan_started', { phase, target: 'Multiple Targets', startTime: scanStartTime, scanKind: options.scanKind || currentScanKind });
+        logEvent(socket, 'job', `Starting Phase ${phase} fallback pass: ${label}...`);
+        logEvent(socket, 'scan', `Nmap command: sudo -n ${NMAP_PATH} ${args.join(' ')}`);
+
+        const nmap = spawn(commandSpec.command, commandSpec.args);
+        currentScan = nmap;
+
+        nmap.stderr.on('data', data => {
+            const errText = data.toString();
+            stderrBuffer = compactErrorText(`${stderrBuffer}\n${errText}`);
+            if (!errText.includes('Warning: ')) console.error('[NMAP ERROR]', errText);
+            if (isSudoAuthFailure(errText)) {
+                logEvent(socket, 'error', 'Nmap requires passwordless sudo for this runtime. Configure sudoers for nmap or run with the required privileges.');
+            }
+        });
+
+        nmap.on('error', error => {
+            currentScan = null;
+            const duration = ((Date.now() - startedAt) / 1000).toFixed(2);
+            logEvent(socket, 'error', `Failed to start Phase ${phase} fallback pass: ${error.message}`);
+            resolve({ success: false, duration, error: error.message, xmlPath: path.join(__dirname, xmlFile) });
+        });
+
+        nmap.on('close', (code, signal) => {
+            currentScan = null;
+            const duration = ((Date.now() - startedAt) / 1000).toFixed(2);
+            const statusText = code === 0 ? 'complete' : `ended with code ${code ?? 'null'}${signal ? `, signal ${signal}` : ''}`;
+            const xmlPath = path.join(__dirname, xmlFile);
+            const complete = isCompleteNmapXML(xmlPath);
+            logEvent(socket, complete ? 'job' : 'error', `Phase ${phase} fallback pass ${statusText} in ${duration}s. XML ${complete ? 'complete' : 'incomplete'}.`);
+            io.emit('phase_complete', { phase, duration, ...getScanStats() });
+            resolve({
+                success: complete,
+                duration,
+                error: compactErrorText(stderrBuffer || `Phase ${phase} fallback pass ${statusText}. XML ${complete ? 'complete' : 'incomplete'}.`),
+                xmlPath
+            });
+        });
+    });
+}
+
+async function runPhase2Fallback(socket, originalDuration, reportScanKind) {
+    const noScriptXml = 'phase2_no_script.xml';
+    const vulnersXml = 'phase2_vulners.xml';
+    [noScriptXml, vulnersXml].forEach(file => {
+        const filePath = path.join(__dirname, file);
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    });
+
+    logEvent(socket, 'job', 'Starting Phase 2 fallback recovery as two passes: 2.1 service/OS detection, then 2.2 vulners only.');
+    const pass21 = await runNmapFallbackPass(socket, [
+        '-sS', '-sV', '-O', '-Pn',
+        '-T3',
+        '--open',
+        '-oX', noScriptXml,
+        '-iL', 'targets.tmp'
+    ], 2.1, noScriptXml, 'service + OS detection without scripts', { scanKind: reportScanKind });
+    if (!pass21.success) {
+        logEvent(socket, 'error', `Phase 2.1 fallback failed: ${pass21.error}`);
+        io.emit('scan_complete', { phase: 2.1, duration: pass21.duration, ...getScanStats(), status: 'failed', error: pass21.error });
+        return;
+    }
+
+    parseNmapXML(pass21.xmlPath, (parsedStats) => {
+        logEvent(socket, 'job', `Phase 2.1 fallback XML parsed. Hosts: ${parsedStats.hostCount}, open ports: ${parsedStats.openPortCount}, critical CVEs: ${parsedStats.criticalCVECount}, LOW CVEs: ${parsedStats.lowCVECount}.`);
+        io.emit('phase_stats', { phase: 2.1, ...parsedStats });
+    });
+
+    const pass22 = await runNmapFallbackPass(socket, [
+        '-sV',
+        '--script', 'vulners',
+        '--script-args', 'threads=8',
+        '-iL', 'targets.tmp',
+        '-oX', vulnersXml
+    ], 2.2, vulnersXml, 'vulners only', { scanKind: reportScanKind });
+    if (!pass22.success) {
+        logEvent(socket, 'error', `Phase 2.2 fallback failed: ${pass22.error}`);
+        io.emit('scan_complete', { phase: 2.2, duration: pass22.duration, ...getScanStats(), status: 'failed', error: pass22.error });
+        return;
+    }
+
+    parseNmapXML(pass22.xmlPath, (parsedStats) => {
+        logEvent(socket, 'job', `Phase 2.2 fallback XML parsed. Hosts: ${parsedStats.hostCount}, open ports: ${parsedStats.openPortCount}, critical CVEs: ${parsedStats.criticalCVECount}, LOW CVEs: ${parsedStats.lowCVECount}.`);
+        io.emit('phase_stats', { phase: 2.2, ...parsedStats });
+    });
+
+    const totalDuration = (Number(originalDuration || 0) + Number(pass21.duration || 0) + Number(pass22.duration || 0)).toFixed(2);
+    generateReportFromXml(socket, pass22.xmlPath, totalDuration, reportScanKind);
+    io.emit('scan_complete', { phase: 2.2, duration: totalDuration, ...getScanStats(), status: 'fallback_complete' });
+}
+
 function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
     if (currentScan && phase === 1) {
         if (socket) logEvent(socket, 'error', 'A scan is already running.');
@@ -917,6 +1094,13 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
                         customerProfile: getCustomerFingerprintProfile(),
                         error: failureError
                     });
+                    if (options.fallbackOnIncomplete) {
+                        runPhase2Fallback(socket, duration, reportScanKind).catch(error => {
+                            logEvent(socket, 'error', `Phase 2 fallback recovery failed: ${error.message}`);
+                            io.emit('scan_complete', { phase, duration, ...phaseStats, status: 'failed', error: error.message });
+                        });
+                        return;
+                    }
                     io.emit('scan_complete', { phase, duration, ...phaseStats, status: 'failed', error: failureError });
                     return;
                 }
@@ -924,85 +1108,12 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
                     logEvent(socket, 'job', `Phase ${phase} XML results parsed. Hosts: ${parsedStats.hostCount}, open ports: ${parsedStats.openPortCount}, critical CVEs: ${parsedStats.criticalCVECount}, LOW CVEs: ${parsedStats.lowCVECount}.`);
                     io.emit('phase_stats', { phase, ...parsedStats });
                 });
-                const profile = getCustomerFingerprintProfile();
-                const reportDir = path.join(REPORTS_DIR, profile.folderName);
-                if (!fs.existsSync(reportDir)) fs.mkdirSync(reportDir, { recursive: true });
-                const reportDate = new Date();
-                const reportTimestamp = formatReportTimestamp(reportDate);
-                const reportDisplayTimestamp = formatReportDisplayTimestamp(reportDate);
-                const reportBaseName = `${profile.reportLabel}-${reportTimestamp}`;
-                const reportName = `${reportBaseName}.html`;
-                const pdfName = `${reportBaseName}.pdf`;
-                const reportPath = path.join(reportDir, reportName);
-                const pdfPath = path.join(reportDir, pdfName);
-                const reportUrl = `/reports/${profile.folderName}/${reportName}`;
-                const pdfUrl = `/reports/${profile.folderName}/${pdfName}`;
-                const xslPath = path.join(__dirname, 'nmap-modern.xsl');
-                const xsltCommand = [
-                    'xsltproc',
-                    '-o', shellQuote(reportPath),
-                    '--stringparam', 'customer_name', shellQuote(profile.prefix),
-                    '--stringparam', 'report_identifier', shellQuote(profile.reportLabel),
-                    '--stringparam', 'report_timestamp', shellQuote(reportTimestamp),
-                    '--stringparam', 'report_display_timestamp', shellQuote(reportDisplayTimestamp),
-                    '--stringparam', 'public_ip', shellQuote(profile.publicIP),
-                    shellQuote(xslPath),
-                    shellQuote(xmlPath)
-                ].join(' ');
-                exec(xsltCommand, (err) => {
-                    if (!err) {
-                        generatePDF(reportPath, pdfPath, (pdfErr) => {
-                            const pdfReady = !pdfErr && fs.existsSync(pdfPath);
-                            if (pdfErr) {
-                                logEvent(socket, 'error', `PDF generation failed for ${reportName}: ${pdfErr.message}`);
-                            }
-                            logEvent(socket, 'report', `Report generated: ${reportName}${pdfReady ? ` and ${pdfName}` : ''}`);
-                            const reportPayload = {
-                                url: reportUrl,
-                                pdfUrl: pdfReady ? pdfUrl : null,
-                                name: reportName,
-                                pdfName: pdfReady ? pdfName : null,
-                                customerProfile: profile
-                            };
-                            io.emit('report_ready', reportPayload);
-                            const history = loadJSON(HISTORY_PATH, []);
-                            history.unshift({
-                                timestamp: new Date().toISOString(),
-                                target: currentTarget,
-                                duration,
-                                hostCount: discoveredHosts.length,
-                                reportUrl,
-                                pdfUrl: pdfReady ? pdfUrl : null,
-                                customerProfile: profile
-                            });
-                            saveJSON(HISTORY_PATH, history.slice(0, 50));
-                            if (['complete', 'quick'].includes(reportScanKind)) {
-                                const uploadLabel = reportScanKind === 'quick' ? 'Quick Scan report' : 'Complete+PDF report';
-                                uploadReportFilesToDrive(socket, [reportPath, pdfReady ? pdfPath : null], profile, {
-                                    label: uploadLabel,
-                                    reportPath,
-                                    dayFolderName: formatDriveDayFolder(reportDate)
-                                })
-                                    .then(result => {
-                                        if (!result?.success) return;
-                                        const metadata = loadDriveMetadata(reportPath);
-                                        io.emit('report_ready', {
-                                            ...reportPayload,
-                                            driveHtmlUrl: findDriveLink(metadata, reportName),
-                                            drivePdfUrl: pdfReady ? findDriveLink(metadata, pdfName) : null
-                                        });
-                                    })
-                                    .catch(error => logEvent(socket, 'error', `Google Drive upload failed for ${uploadLabel}: ${error.message}`));
-                            }
-                        });
-                    } else {
-                        logEvent(socket, 'error', `HTML report generation failed: ${err.message}`);
-                    }
-                });
+                generateReportFromXml(socket, xmlPath, duration, reportScanKind);
+                if (options.deferScanComplete) io.emit('scan_complete', { phase, duration, ...phaseStats });
             }, 1000);
         }
         if (onComplete) onComplete();
-        else io.emit('scan_complete', { phase, duration, ...phaseStats });
+        else if (!options.deferScanComplete) io.emit('scan_complete', { phase, duration, ...phaseStats });
     });
 }
 
@@ -1100,7 +1211,7 @@ function startChainedScan(socket, target, usePn = false) {
                 }),
                 2,
                 null,
-                { deferHostUpdates: true, scanKind }
+                { deferHostUpdates: true, scanKind, fallbackOnIncomplete: true, deferScanComplete: true }
             );
             return;
         }

--- a/server.js
+++ b/server.js
@@ -60,7 +60,6 @@ let cachedPublicIP = null;
 const CONFIG_PATH = path.join(__dirname, 'config.json');
 const HISTORY_PATH = path.join(__dirname, 'history.json');
 const REPORTS_DIR = path.join(__dirname, 'reports_archive');
-const PHASE2_MAX_HOSTGROUP = String(Math.max(1, parseInt(process.env.NMAP_MAX_HOSTGROUP || '4', 10) || 4));
 const NMAP_PATH = resolveExecutable(process.env.NMAP_PATH, [
     '/opt/homebrew/bin/nmap',
     '/usr/local/bin/nmap',
@@ -74,6 +73,11 @@ const TRACEROUTE_PATH = resolveExecutable(process.env.TRACEROUTE_PATH, [
     '/opt/homebrew/bin/traceroute',
     '/usr/local/bin/traceroute',
     'traceroute'
+]);
+const BREW_PATH = resolveExecutable(process.env.BREW_PATH, [
+    '/opt/homebrew/bin/brew',
+    '/usr/local/bin/brew',
+    'brew'
 ]);
 let customerProfileConfig = loadJSON(CONFIG_PATH, {}).customerProfile || {};
 let appConfig = loadJSON(CONFIG_PATH, {});
@@ -149,6 +153,84 @@ function getPrivilegedCommand(executablePath, args) {
 
 function describeMissingExecutable(name, envVar) {
     return `${name} was not found. Install it or set ${envVar} to the executable path.`;
+}
+
+function getBrewCommand(args) {
+    if (process.getuid && process.getuid() === 0) {
+        const sudoUser = process.env.SUDO_USER;
+        if (!sudoUser || sudoUser === 'root') return null;
+        return {
+            command: 'sudo',
+            args: ['-u', sudoUser, BREW_PATH, ...args],
+            env: { ...process.env, HOME: `/Users/${sudoUser}`, USER: sudoUser }
+        };
+    }
+    return { command: BREW_PATH, args, env: process.env };
+}
+
+function runBrewStep(args) {
+    return new Promise((resolve) => {
+        const commandSpec = getBrewCommand(args);
+        if (!BREW_PATH || !commandSpec) {
+            resolve({ success: false, error: 'Homebrew is unavailable or cannot be run from the current user context.' });
+            return;
+        }
+
+        const brew = spawn(commandSpec.command, commandSpec.args, { env: commandSpec.env });
+        brew.stdout.on('data', data => {
+            const text = data.toString().trim();
+            if (text) console.log(`[BREW] ${text}`);
+        });
+        brew.stderr.on('data', data => {
+            const text = data.toString().trim();
+            if (text) console.warn(`[BREW] ${text}`);
+        });
+        brew.on('error', error => resolve({ success: false, error: error.message }));
+        brew.on('close', code => resolve({ success: code === 0, error: code === 0 ? '' : `brew ${args.join(' ')} exited with code ${code}` }));
+    });
+}
+
+async function updateNmapFromHomebrew() {
+    if (!BREW_PATH) {
+        console.warn('Skipping Homebrew nmap upgrade: brew was not found.');
+        return;
+    }
+    const commandSpec = getBrewCommand(['update']);
+    if (!commandSpec) {
+        console.warn('Skipping Homebrew nmap upgrade: brew cannot run as root without SUDO_USER.');
+        return;
+    }
+
+    console.log('Startup - Running brew update && brew upgrade nmap...');
+    const update = await runBrewStep(['update']);
+    if (!update.success) {
+        console.warn(`Skipping brew upgrade nmap: ${update.error}`);
+        return;
+    }
+    const upgrade = await runBrewStep(['upgrade', 'nmap']);
+    if (!upgrade.success) {
+        console.warn(`Homebrew nmap upgrade did not complete: ${upgrade.error}`);
+    }
+}
+
+function updateNmapScriptDatabase() {
+    if (!NMAP_PATH) {
+        console.warn(describeMissingExecutable('nmap', 'NMAP_PATH'));
+        return;
+    }
+
+    console.log('Prescan - Updating scripts...');
+    const updateCommand = getPrivilegedCommand(NMAP_PATH, ['--script-updatedb']);
+    const updateProcess = spawn(updateCommand.command, updateCommand.args);
+    updateProcess.stderr.on('data', data => {
+        const text = data.toString();
+        if (isSudoAuthFailure(text)) {
+            console.warn('Skipping nmap script update: passwordless sudo is required.');
+        } else if (!text.includes('Warning: ')) {
+            console.warn(`[NMAP UPDATE] ${text.trim()}`);
+        }
+    });
+    updateProcess.on('error', error => console.warn(`Skipping nmap script update: ${error.message}`));
 }
 
 function isSudoAuthFailure(text) {
@@ -458,24 +540,28 @@ function isCompleteNmapXML(xmlPath) {
 }
 
 function buildPhase2Args(usePn = false, fullPortScan = false, options = {}) {
-    const hostGroupArgs = options.allHostsAtOnce
-        ? []
-        : ['--min-hostgroup', '1', '--max-hostgroup', PHASE2_MAX_HOSTGROUP];
+    const hostGroupArgs = options.hostGroup
+        ? ['--min-hostgroup', '1', '--max-hostgroup', String(options.hostGroup)]
+        : [];
     const scripts = options.disableScripts ? [] : (options.consolidateScripts ? ['default,vulners'] : ['vulners']);
-    const rateArgs = options.minRate === false ? [] : ['--min-rate', options.minRate || '3000'];
+    const rateArgs = options.minRate ? ['--min-rate', String(options.minRate)] : [];
     const defaultScriptArgs = options.includeDefaultScripts === false || options.consolidateScripts ? [] : ['-sC'];
+    const scriptArgs = scripts.length && options.scriptArgs !== false
+        ? ['--script-args', options.scriptArgs || 'mincvss=0,threads=10']
+        : [];
     const args = [
         ...(fullPortScan ? ['-p-'] : []),
         '-sS', '-sV',
         ...defaultScriptArgs,
         '-O',
         ...(usePn ? ['-Pn'] : []),
-        '-T4',
+        options.timing || '-T3',
         ...rateArgs,
         ...(options.maxParallelism ? ['--max-parallelism', String(options.maxParallelism)] : []),
         ...hostGroupArgs,
         '--open',
         ...(scripts.length ? ['--script', scripts.join(',')] : []),
+        ...scriptArgs,
         '--stylesheet', 'nmap-modern.xsl',
         '-oX', 'phase2_results.xml',
         '-iL', 'targets.tmp'
@@ -1010,8 +1096,7 @@ function startChainedScan(socket, target, usePn = false) {
                 socket,
                 buildPhase2Args(true, false, {
                     includeDefaultScripts: false,
-                    minRate: false,
-                    allHostsAtOnce: true
+                    minRate: false
                 }),
                 2,
                 null,
@@ -1150,22 +1235,7 @@ io.on('connection', (socket) => {
 });
 
 // Initialization
-if (NMAP_PATH) {
-    console.log('Prescan - Updating scripts...');
-    const updateCommand = getPrivilegedCommand(NMAP_PATH, ['--script-updatedb']);
-    const updateProcess = spawn(updateCommand.command, updateCommand.args);
-    updateProcess.stderr.on('data', data => {
-        const text = data.toString();
-        if (isSudoAuthFailure(text)) {
-            console.warn('Skipping nmap script update: passwordless sudo is required.');
-        } else if (!text.includes('Warning: ')) {
-            console.warn(`[NMAP UPDATE] ${text.trim()}`);
-        }
-    });
-    updateProcess.on('error', error => console.warn(`Skipping nmap script update: ${error.message}`));
-} else {
-    console.warn(describeMissingExecutable('nmap', 'NMAP_PATH'));
-}
+updateNmapFromHomebrew().finally(updateNmapScriptDatabase);
 
 setupAutoScan(loadJSON(CONFIG_PATH, {}));
 getNetworkInfo(); getPublicIP(); runTraceroute();

--- a/server.js
+++ b/server.js
@@ -31,7 +31,7 @@ app.get('/google-drive/oauth2callback', async (req, res) => {
         const googleDrive = saveGoogleDriveConfig({ enabled: true });
         logEvent(null, 'settings', 'Google Drive connected and sync enabled.');
         io.emit('google_drive_status', { ...result, config: googleDrive });
-        res.send('<html><body><h1>Google Drive connected</h1><p>You can close this window and return to Gemini Nmap.</p></body></html>');
+        res.send('<html><body><h1>Google Drive connected</h1><p>You can close this window and return to TM-NMapUI.</p></body></html>');
         return;
     }
     io.emit('google_drive_status', { ...result, config: getGoogleDriveConfig() });
@@ -190,7 +190,7 @@ function generatePDF(reportPath, pdfPath, callback) {
         '--enable-local-file-access',
         '--print-media-type',
         '--page-size', 'Letter',
-        '--orientation', 'Landscape',
+        '--orientation', 'Portrait',
         '--margin-top', '8mm',
         '--margin-right', '8mm',
         '--margin-bottom', '8mm',
@@ -235,6 +235,46 @@ function formatReportDisplayTimestamp(date = new Date()) {
         hour12: false,
         timeZoneName: 'short'
     });
+}
+
+function formatDriveDayFolder(date = new Date()) {
+    const pad = value => String(value).padStart(2, '0');
+    return [
+        date.getFullYear(),
+        pad(date.getMonth() + 1),
+        pad(date.getDate())
+    ].join('-');
+}
+
+function getDriveMetadataPath(reportPath) {
+    return `${reportPath}.drive.json`;
+}
+
+function saveDriveMetadata(reportPath, result) {
+    if (!reportPath || !result?.success) return null;
+    const metadataPath = getDriveMetadataPath(reportPath);
+    const metadata = {
+        uploadedAt: new Date().toISOString(),
+        folderId: result.folder_id || null,
+        dayFolderId: result.day_folder_id || null,
+        links: (result.uploaded || []).map(file => ({
+            name: file.name || '',
+            webViewLink: file.webViewLink || '',
+            id: file.id || ''
+        })).filter(file => file.name || file.webViewLink || file.id)
+    };
+    saveJSON(metadataPath, metadata);
+    return metadata;
+}
+
+function loadDriveMetadata(reportPath) {
+    const metadata = loadJSON(getDriveMetadataPath(reportPath), null);
+    if (!metadata || !Array.isArray(metadata.links)) return null;
+    return metadata;
+}
+
+function findDriveLink(metadata, fileName) {
+    return (metadata?.links || []).find(file => file.name === fileName)?.webViewLink || null;
 }
 
 function getTopologyFingerprintParts() {
@@ -313,8 +353,9 @@ async function uploadReportFilesToDrive(socket, filePaths, profile, context = {}
         return null;
     }
 
-    const folderName = profile?.folderName ? `Gemini Nmap Reports/${profile.folderName}` : 'Gemini Nmap Reports';
-    const args = ['upload', '--folder-name', folderName, '--files', ...existingFiles];
+    const folderName = 'Nmap Reports';
+    const dayFolderName = context.dayFolderName || formatDriveDayFolder();
+    const args = ['upload', '--folder-name', folderName, '--day-folder-name', dayFolderName, '--files', ...existingFiles];
     if (googleDrive.folderId) args.splice(1, 0, '--folder-id', googleDrive.folderId);
 
     const fileNames = existingFiles.map(filePath => path.basename(filePath)).join(', ');
@@ -330,6 +371,10 @@ async function uploadReportFilesToDrive(socket, filePaths, profile, context = {}
             .map(file => file.webViewLink)
             .filter(Boolean)
             .forEach(link => logEvent(socket, 'report', `Google Drive file link: ${link}`));
+        if (context.reportPath) {
+            saveDriveMetadata(context.reportPath, result);
+            io.emit('reports_refresh');
+        }
         io.emit('google_drive_upload_complete', { ...result, label });
     } else {
         logEvent(socket, 'error', `Google Drive upload failed for ${label}: ${result.error || 'Unknown error'}`);
@@ -724,13 +769,14 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
                                 logEvent(socket, 'error', `PDF generation failed for ${reportName}: ${pdfErr.message}`);
                             }
                             logEvent(socket, 'report', `Report generated: ${reportName}${pdfReady ? ` and ${pdfName}` : ''}`);
-                            io.emit('report_ready', {
+                            const reportPayload = {
                                 url: reportUrl,
                                 pdfUrl: pdfReady ? pdfUrl : null,
                                 name: reportName,
                                 pdfName: pdfReady ? pdfName : null,
                                 customerProfile: profile
-                            });
+                            };
+                            io.emit('report_ready', reportPayload);
                             const history = loadJSON(HISTORY_PATH, []);
                             history.unshift({
                                 timestamp: new Date().toISOString(),
@@ -744,7 +790,20 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
                             saveJSON(HISTORY_PATH, history.slice(0, 50));
                             if (['complete', 'quick'].includes(reportScanKind)) {
                                 const uploadLabel = reportScanKind === 'quick' ? 'Quick Scan report' : 'Complete+PDF report';
-                                uploadReportFilesToDrive(socket, [reportPath, pdfReady ? pdfPath : null], profile, { label: uploadLabel })
+                                uploadReportFilesToDrive(socket, [reportPath, pdfReady ? pdfPath : null], profile, {
+                                    label: uploadLabel,
+                                    reportPath,
+                                    dayFolderName: formatDriveDayFolder(reportDate)
+                                })
+                                    .then(result => {
+                                        if (!result?.success) return;
+                                        const metadata = loadDriveMetadata(reportPath);
+                                        io.emit('report_ready', {
+                                            ...reportPayload,
+                                            driveHtmlUrl: findDriveLink(metadata, reportName),
+                                            drivePdfUrl: pdfReady ? findDriveLink(metadata, pdfName) : null
+                                        });
+                                    })
                                     .catch(error => logEvent(socket, 'error', `Google Drive upload failed for ${uploadLabel}: ${error.message}`));
                             }
                         });
@@ -947,7 +1006,9 @@ io.on('connection', (socket) => {
                 : [entry.name];
             files.forEach(f => {
                 const pdfName = f.replace(/\.html$/i, '.pdf');
+                const reportPath = path.join(folderPath, f);
                 const pdfPath = path.join(folderPath, pdfName);
+                const driveMetadata = loadDriveMetadata(reportPath);
                 const urlBase = folder ? `/reports/${folder}` : '/reports';
                 reports.push({
                     name: f,
@@ -955,7 +1016,9 @@ io.on('connection', (socket) => {
                     url: `${urlBase}/${f}`,
                     pdfName: fs.existsSync(pdfPath) ? pdfName : null,
                     pdfUrl: fs.existsSync(pdfPath) ? `${urlBase}/${pdfName}` : null,
-                    date: fs.statSync(path.join(folderPath, f)).mtime
+                    driveHtmlUrl: findDriveLink(driveMetadata, f),
+                    drivePdfUrl: fs.existsSync(pdfPath) ? findDriveLink(driveMetadata, pdfName) : null,
+                    date: fs.statSync(reportPath).mtime
                 });
             });
         });

--- a/server.js
+++ b/server.js
@@ -15,11 +15,16 @@ const app = express();
 const server = http.createServer(app);
 const io = new Server(server);
 
-const PORT = process.env.PORT || 9000;
+const APP_IDENTITY = 'tm-network-scanner';
+const PORT = Number(process.env.PORT || 9000);
 
 app.use(express.static(path.join(__dirname)));
 app.use('/static', express.static(path.join(__dirname, 'static')));
 app.use('/reports', express.static(path.join(__dirname, 'reports_archive')));
+
+app.get('/api/app-identity', (req, res) => {
+    res.json({ app: APP_IDENTITY, name: 'TM-NMapUI', version: VERSION });
+});
 
 app.get('/google-drive/oauth2callback', async (req, res) => {
     const result = await runGoogleDriveHelper([
@@ -148,6 +153,69 @@ function describeMissingExecutable(name, envVar) {
 
 function isSudoAuthFailure(text) {
     return /sudo:.*password|a password is required|no tty present|permission denied/i.test(text || '');
+}
+
+function requestJSON(url, timeoutMs = 1000) {
+    return new Promise((resolve) => {
+        const request = http.get(url, { timeout: timeoutMs }, response => {
+            let raw = '';
+            response.on('data', chunk => { raw += chunk.toString(); });
+            response.on('end', () => {
+                try {
+                    resolve(JSON.parse(raw || '{}'));
+                } catch (error) {
+                    resolve(null);
+                }
+            });
+        });
+        request.on('timeout', () => {
+            request.destroy();
+            resolve(null);
+        });
+        request.on('error', () => resolve(null));
+    });
+}
+
+function getPortListenerPids(port) {
+    return new Promise((resolve) => {
+        exec(`lsof -ti tcp:${Number(port)} -sTCP:LISTEN`, (error, stdout) => {
+            if (error || !stdout.trim()) {
+                resolve([]);
+                return;
+            }
+            resolve(stdout.trim().split(/\s+/).map(pid => Number(pid)).filter(Boolean));
+        });
+    });
+}
+
+async function stopExistingAppOnPort(port) {
+    const identity = await requestJSON(`http://127.0.0.1:${port}/api/app-identity`);
+    if (identity?.app !== APP_IDENTITY) {
+        return false;
+    }
+
+    const pids = (await getPortListenerPids(port)).filter(pid => pid !== process.pid);
+    if (pids.length === 0) return false;
+
+    console.warn(`Port ${port} is already used by ${identity.name || APP_IDENTITY}; stopping pid(s): ${pids.join(', ')}`);
+    pids.forEach(pid => {
+        try {
+            process.kill(pid, 'SIGTERM');
+        } catch (error) {
+            console.warn(`Failed to stop pid ${pid}: ${error.message}`);
+        }
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 1200));
+    const remaining = (await getPortListenerPids(port)).filter(pid => pid !== process.pid);
+    remaining.forEach(pid => {
+        try {
+            process.kill(pid, 'SIGKILL');
+        } catch (error) {
+            console.warn(`Failed to force stop pid ${pid}: ${error.message}`);
+        }
+    });
+    return true;
 }
 
 function shellQuote(value) {
@@ -1046,4 +1114,22 @@ if (NMAP_PATH) {
 
 setupAutoScan(loadJSON(CONFIG_PATH, {}));
 getNetworkInfo(); getPublicIP(); runTraceroute();
-server.listen(PORT, () => console.log(`${VERSION} Server running on http://localhost:${PORT}`));
+
+function listenWithPortGuard(retried = false) {
+    server.once('error', async error => {
+        if (error.code !== 'EADDRINUSE' || retried) {
+            console.error(`Failed to start server on port ${PORT}: ${error.message}`);
+            process.exit(1);
+        }
+        const stopped = await stopExistingAppOnPort(PORT);
+        if (!stopped) {
+            console.error(`Port ${PORT} is already in use by another service. Stop it or set PORT to a different value.`);
+            process.exit(1);
+        }
+        listenWithPortGuard(true);
+    });
+    server.listen(PORT);
+}
+
+server.on('listening', () => console.log(`${VERSION} Server running on http://localhost:${PORT}`));
+listenWithPortGuard();

--- a/server.js
+++ b/server.js
@@ -483,6 +483,28 @@ function buildPhase2Args(usePn = false, fullPortScan = false, options = {}) {
     return args;
 }
 
+function compactErrorText(value, maxLength = 4000) {
+    const text = String(value || '').replace(/\s+\n/g, '\n').trim();
+    if (text.length <= maxLength) return text;
+    return text.slice(-maxLength).trim();
+}
+
+function saveFailedScanHistory({ target, duration, hostCount, scanKind, customerProfile, error }) {
+    const history = loadJSON(HISTORY_PATH, []);
+    history.unshift({
+        timestamp: new Date().toISOString(),
+        target,
+        duration,
+        hostCount,
+        scanKind,
+        status: 'failed',
+        error: compactErrorText(error),
+        customerProfile
+    });
+    saveJSON(HISTORY_PATH, history.slice(0, 50));
+    io.emit('reports_refresh');
+}
+
 function setupAutoScan(config) {
     if (autoScanTask) autoScanTask.stop();
     autoScanTask = null;
@@ -735,6 +757,7 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
 
     let currentHostIP = null;
     let hostBuffer = [];
+    let stderrBuffer = '';
 
     nmap.stdout.on('data', (data) => {
         const text = data.toString();
@@ -772,6 +795,7 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
 
     nmap.stderr.on('data', (data) => {
         const errText = data.toString();
+        stderrBuffer = compactErrorText(`${stderrBuffer}\n${errText}`);
         if (!errText.includes('Warning: ')) console.error('[NMAP ERROR]', errText);
         if (isSudoAuthFailure(errText)) {
             logEvent(socket, 'error', 'Nmap requires passwordless sudo for this runtime. Configure sudoers for nmap or run with the required privileges.');
@@ -797,27 +821,17 @@ function runNmap(socket, args, phase = 1, onComplete = null, options = {}) {
             const reportScanKind = options.scanKind || currentScanKind;
             setTimeout(() => {
                 if (!isCompleteNmapXML(xmlPath)) {
-                    if (options.retryWithoutVulners && !options.retriedWithoutVulners) {
-                        logEvent(socket, 'error', 'Phase 2 XML is incomplete after the vulners/NSE run. Retrying once without NSE scripts so a report can still be generated.');
-                        runNmap(
-                            socket,
-                            buildPhase2Args(true, false, {
-                                includeDefaultScripts: false,
-                                disableScripts: true,
-                                minRate: false,
-                                maxParallelism: 4
-                            }),
-                            phase,
-                            onComplete,
-                            {
-                                deferHostUpdates: true,
-                                scanKind: reportScanKind,
-                                retriedWithoutVulners: true
-                            }
-                        );
-                        return;
-                    }
-                    logEvent(socket, 'error', 'Phase 2 XML is incomplete, likely because Nmap/NSE crashed. Skipping XML parse and report/PDF generation for this run.');
+                    const failureError = compactErrorText(stderrBuffer || `Phase ${phase} scan ${statusText}. XML output was incomplete.`);
+                    logEvent(socket, 'error', 'Phase 2 XML is incomplete, likely because Nmap/NSE crashed. Recording this run as failed so it remains visible in history and reports.');
+                    saveFailedScanHistory({
+                        target: currentTarget,
+                        duration,
+                        hostCount: phaseStats.hostCount,
+                        scanKind: reportScanKind,
+                        customerProfile: getCustomerFingerprintProfile(),
+                        error: failureError
+                    });
+                    io.emit('scan_complete', { phase, duration, ...phaseStats, status: 'failed', error: failureError });
                     return;
                 }
                 parseNmapXML(xmlPath, (parsedStats) => {
@@ -991,17 +1005,17 @@ function startChainedScan(socket, target, usePn = false) {
         fs.writeFileSync('targets.tmp', targets);
 
         if (usePn) {
-            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning ${discoveredHosts.length} host(s) with bounded hostgroups to reduce NSE/vulners crashes. UI details will populate after XML parsing completes.`);
+            logEvent(socket, 'job', `Complete+PDF Phase 2 scanning all ${discoveredHosts.length} host(s) in one Nmap command with vulners. UI details will populate after XML parsing completes.`);
             runNmap(
                 socket,
                 buildPhase2Args(true, false, {
                     includeDefaultScripts: false,
                     minRate: false,
-                    maxParallelism: 4
+                    allHostsAtOnce: true
                 }),
                 2,
                 null,
-                { deferHostUpdates: true, scanKind, retryWithoutVulners: true }
+                { deferHostUpdates: true, scanKind }
             );
             return;
         }
@@ -1083,33 +1097,54 @@ io.on('connection', (socket) => {
         io.emit('customer_profile', profile);
     });
     socket.on('get_reports', () => {
-        if (!fs.existsSync(REPORTS_DIR)) return;
         const reports = [];
-        fs.readdirSync(REPORTS_DIR, { withFileTypes: true }).forEach(entry => {
-            const folder = entry.isDirectory() ? entry.name : '';
-            const folderPath = folder ? path.join(REPORTS_DIR, folder) : REPORTS_DIR;
-            if (!entry.isDirectory() && !entry.name.endsWith('.html')) return;
-            const files = entry.isDirectory()
-                ? fs.readdirSync(folderPath).filter(f => f.endsWith('.html'))
-                : [entry.name];
-            files.forEach(f => {
-                const pdfName = f.replace(/\.html$/i, '.pdf');
-                const reportPath = path.join(folderPath, f);
-                const pdfPath = path.join(folderPath, pdfName);
-                const driveMetadata = loadDriveMetadata(reportPath);
-                const urlBase = folder ? `/reports/${folder}` : '/reports';
-                reports.push({
-                    name: f,
-                    folder,
-                    url: `${urlBase}/${f}`,
-                    pdfName: fs.existsSync(pdfPath) ? pdfName : null,
-                    pdfUrl: fs.existsSync(pdfPath) ? `${urlBase}/${pdfName}` : null,
-                    driveHtmlUrl: findDriveLink(driveMetadata, f),
-                    drivePdfUrl: fs.existsSync(pdfPath) ? findDriveLink(driveMetadata, pdfName) : null,
-                    date: fs.statSync(reportPath).mtime
+        if (fs.existsSync(REPORTS_DIR)) {
+            fs.readdirSync(REPORTS_DIR, { withFileTypes: true }).forEach(entry => {
+                const folder = entry.isDirectory() ? entry.name : '';
+                const folderPath = folder ? path.join(REPORTS_DIR, folder) : REPORTS_DIR;
+                if (!entry.isDirectory() && !entry.name.endsWith('.html')) return;
+                const files = entry.isDirectory()
+                    ? fs.readdirSync(folderPath).filter(f => f.endsWith('.html'))
+                    : [entry.name];
+                files.forEach(f => {
+                    const pdfName = f.replace(/\.html$/i, '.pdf');
+                    const reportPath = path.join(folderPath, f);
+                    const pdfPath = path.join(folderPath, pdfName);
+                    const driveMetadata = loadDriveMetadata(reportPath);
+                    const urlBase = folder ? `/reports/${folder}` : '/reports';
+                    reports.push({
+                        name: f,
+                        folder,
+                        url: `${urlBase}/${f}`,
+                        pdfName: fs.existsSync(pdfPath) ? pdfName : null,
+                        pdfUrl: fs.existsSync(pdfPath) ? `${urlBase}/${pdfName}` : null,
+                        driveHtmlUrl: findDriveLink(driveMetadata, f),
+                        drivePdfUrl: fs.existsSync(pdfPath) ? findDriveLink(driveMetadata, pdfName) : null,
+                        date: fs.statSync(reportPath).mtime
+                    });
                 });
             });
-        });
+        }
+        loadJSON(HISTORY_PATH, [])
+            .filter(entry => entry && entry.status === 'failed')
+            .forEach(entry => {
+                const date = entry.timestamp || new Date().toISOString();
+                const scanLabel = entry.scanKind === 'complete' ? 'Complete+PDF' : (entry.scanKind || 'Scan');
+                reports.push({
+                    name: `Failed ${scanLabel} scan - ${new Date(date).toLocaleString()}`,
+                    folder: entry.customerProfile?.folderName || '',
+                    url: null,
+                    pdfName: null,
+                    pdfUrl: null,
+                    driveHtmlUrl: null,
+                    drivePdfUrl: null,
+                    date,
+                    status: 'failed',
+                    error: entry.error || 'Nmap scan failed before a complete XML report was written.',
+                    hostCount: entry.hostCount,
+                    duration: entry.duration
+                });
+            });
         socket.emit('reports_data', reports.sort((a, b) => new Date(b.date) - new Date(a.date)));
     });
 });

--- a/static/js/customer_ui.js
+++ b/static/js/customer_ui.js
@@ -28,6 +28,70 @@ function saveLocalCustomers(customers) {
     localStorage.setItem('gemini-nmap-customers', JSON.stringify(customers));
 }
 
+function normalizeCustomerMatchValue(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function getCurrentNetworkCustomerSignals(profile = window.currentCustomerProfile || {}) {
+    return new Set([
+        profile.prefix,
+        profile.baseName,
+        profile.reportLabel,
+        profile.folderName,
+        profile.fingerprint,
+        profile.publicIP,
+        document.getElementById('scan-target')?.value,
+        document.getElementById('cidr-value')?.textContent,
+        document.getElementById('public-ip-value')?.textContent,
+        document.getElementById('local-ip-value')?.textContent
+    ].map(normalizeCustomerMatchValue).filter(Boolean));
+}
+
+function customerMatchesCurrentNetwork(customer, signals) {
+    const fields = [customer.id, customer.name, customer.target, customer.publicIP, customer.folderName, customer.fingerprint];
+    return fields.some(field => {
+        const value = normalizeCustomerMatchValue(field);
+        if (!value) return false;
+        if (signals.has(value)) return true;
+        return Array.from(signals).some(signal => signal && (value.includes(signal) || signal.includes(value)));
+    });
+}
+
+function syncCustomerSelectors(profile = window.currentCustomerProfile || {}) {
+    const customers = loadLocalCustomers();
+    const profileId = profile.fingerprint || profile.folderName ? `profile:${profile.fingerprint || profile.folderName}` : '';
+    const currentProfileCustomer = profileId ? {
+        id: profileId,
+        name: profile.prefix || profile.baseName || profile.reportLabel || 'Current Network',
+        target: profile.publicIP || profile.folderName || ''
+    } : null;
+    const selectors = [
+        document.getElementById('customer-quick-add'),
+        document.getElementById('current-customer'),
+        document.getElementById('settings-profile-customer')
+    ].filter(Boolean);
+    const signals = getCurrentNetworkCustomerSignals(profile);
+    const matchedCustomer = customers.find(customer => customerMatchesCurrentNetwork(customer, signals));
+    const selectedCustomer = matchedCustomer || currentProfileCustomer;
+
+    selectors.forEach(select => {
+        const previousValue = select.value;
+        const placeholder = select.id === 'settings-profile-customer'
+            ? 'Use current customer selection'
+            : 'Unassigned Network';
+        select.replaceChildren(new Option(placeholder, ''));
+        if (currentProfileCustomer && !matchedCustomer) {
+            select.appendChild(new Option(currentProfileCustomer.name, currentProfileCustomer.id));
+        }
+        customers.forEach(customer => {
+            select.appendChild(new Option(customer.name || customer.target || 'Unnamed Customer', customer.id));
+        });
+        select.value = selectedCustomer?.id || previousValue || '';
+    });
+
+    window.currentMatchedCustomerId = selectedCustomer?.id || selectors[0]?.value || 'unknown';
+}
+
 function escapeCustomerHTML(value) {
     return String(value).replace(/[&<>"']/g, char => ({
         '&': '&amp;',
@@ -40,6 +104,7 @@ function escapeCustomerHTML(value) {
 
 function renderCustomerFingerprint(profile) {
     if (!profile) return;
+    window.currentCustomerProfile = profile;
     const prefixInput = document.getElementById('customer-profile-prefix');
     const summary = document.getElementById('customer-fingerprint-summary');
     const folder = document.getElementById('customer-fingerprint-folder');
@@ -51,10 +116,12 @@ function renderCustomerFingerprint(profile) {
     if (folder) {
         folder.textContent = `Reports folder: reports_archive/${profile.folderName || 'pending'}`;
     }
+    syncCustomerSelectors(profile);
 }
 
 function renderCustomersTab(customers = loadLocalCustomers()) {
     const list = document.getElementById('customers-tab-list');
+    syncCustomerSelectors();
     if (!list) return;
     list.replaceChildren();
 
@@ -93,6 +160,7 @@ function showCustomerForm() {
     customers.unshift({ id: String(Date.now()), name, target });
     saveLocalCustomers(customers);
     renderCustomersTab(customers);
+    syncCustomerSelectors();
 }
 
 function initializeCustomerUI() {
@@ -106,6 +174,11 @@ function initializeCustomerUI() {
         window.socket?.emit('set_customer_profile_prefix', { prefix });
         setCustomerTabStatus('Customer report prefix saved.');
     });
+    document.getElementById('customer-quick-add')?.addEventListener('change', event => {
+        window.currentMatchedCustomerId = event.target.value || 'unknown';
+        const hiddenSelector = document.getElementById('current-customer');
+        if (hiddenSelector) hiddenSelector.value = event.target.value;
+    });
     window.socket?.on('customer_profile', renderCustomerFingerprint);
     document.getElementById('customers-tab-list')?.addEventListener('click', event => {
         const button = event.target.closest('.delete-customer-btn');
@@ -113,10 +186,13 @@ function initializeCustomerUI() {
         const customers = loadLocalCustomers().filter(customer => customer.id !== button.dataset.id);
         saveLocalCustomers(customers);
         renderCustomersTab(customers);
+        syncCustomerSelectors();
     });
+    syncCustomerSelectors();
 }
 
 window.initializeCustomerUI = initializeCustomerUI;
 window.loadCustomersTab = loadCustomersTab;
 window.showCustomerForm = showCustomerForm;
 window.renderCustomerFingerprint = renderCustomerFingerprint;
+window.syncCustomerSelectors = syncCustomerSelectors;

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -296,22 +296,26 @@ function initializeScanRuntime(socket) {
                 historyStatus.textContent = '';
                 historyStatus.classList.add('hidden');
             }
-            historyList.innerHTML = data.map(item => `
-                <div class="bg-white border border-olive-200 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow">
+            historyList.innerHTML = data.map(item => {
+                const failed = item.status === 'failed';
+                return `
+                <div class="bg-white border ${failed ? 'border-red-200' : 'border-olive-200'} rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow">
                     <div class="flex justify-between items-start mb-4">
-                        <span class="text-[10px] font-bold text-olive-400 uppercase tracking-widest">${new Date(item.timestamp).toLocaleString()}</span>
-                        <span class="px-2 py-1 bg-olive-100 text-olive-700 text-[10px] font-bold rounded-lg">${item.duration}s</span>
+                        <span class="text-[10px] font-bold ${failed ? 'text-red-500' : 'text-olive-400'} uppercase tracking-widest">${new Date(item.timestamp).toLocaleString()}</span>
+                        <span class="px-2 py-1 ${failed ? 'bg-red-100 text-red-700' : 'bg-olive-100 text-olive-700'} text-[10px] font-bold rounded-lg">${failed ? 'FAILED' : `${item.duration}s`}</span>
                     </div>
                     <div class="mb-4">
                         <h4 class="text-olive-900 font-bold text-lg">${item.customerProfile?.baseName || item.target}</h4>
                         <p class="text-xs text-olive-500">${item.hostCount} Hosts Discovered${item.customerProfile?.folderName ? ` | ${item.customerProfile.folderName}` : ''}</p>
+                        ${failed && item.error ? `<p class="mt-2 line-clamp-2 rounded-lg bg-red-50 p-2 font-mono text-[10px] text-red-700">${escapeHTML(item.error)}</p>` : ''}
                     </div>
                     <div class="grid gap-2 sm:grid-cols-2">
-                        <a href="${item.reportUrl}" target="_blank" class="block text-center py-2 bg-olive-50 text-olive-700 text-xs font-bold rounded-xl hover:bg-olive-100 transition-colors">OPEN HTML</a>
+                        ${item.reportUrl ? `<a href="${item.reportUrl}" target="_blank" class="block text-center py-2 bg-olive-50 text-olive-700 text-xs font-bold rounded-xl hover:bg-olive-100 transition-colors">OPEN HTML</a>` : ''}
                         ${item.pdfUrl ? `<a href="${item.pdfUrl}" target="_blank" class="block text-center py-2 bg-red-50 text-red-700 text-xs font-bold rounded-xl hover:bg-red-100 transition-colors">OPEN PDF</a>` : ''}
                     </div>
                 </div>
-            `).join('');
+            `;
+            }).join('');
         }
     });
 
@@ -337,6 +341,7 @@ function initializeScanRuntime(socket) {
                 reportsStatus.classList.add('hidden');
             }
             reportsList.innerHTML = data.map(report => {
+                const failed = report.status === 'failed';
                 const actions = [
                     reportActionLink({ href: report.url, title: 'Open HTML report', icon: 'file-code-2' }),
                     reportActionLink({ href: report.pdfUrl, title: 'Open PDF report', icon: 'file-text', disabled: !report.pdfUrl }),
@@ -344,16 +349,17 @@ function initializeScanRuntime(socket) {
                     reportActionLink({ href: report.driveHtmlUrl || report.drivePdfUrl, title: 'Open in Google Drive', icon: 'cloud', disabled: !(report.driveHtmlUrl || report.drivePdfUrl) })
                 ].join('');
                 return `
-                    <div class="bg-white border border-olive-200 rounded-lg p-3 shadow-sm transition-shadow hover:shadow-md">
+                    <div class="bg-white border ${failed ? 'border-red-200' : 'border-olive-200'} rounded-lg p-3 shadow-sm transition-shadow hover:shadow-md">
                         <div class="flex items-start justify-between gap-3">
                             <div class="min-w-0">
                                 <h4 class="truncate text-sm font-bold text-olive-900" title="${escapeHTML(report.name)}">${escapeHTML(report.name)}</h4>
                                 <p class="mt-0.5 truncate font-mono text-[10px] text-olive-500" title="${escapeHTML(report.folder || '')}">${escapeHTML(report.folder || 'reports')}</p>
                             </div>
-                            <span class="shrink-0 text-[10px] font-bold uppercase text-olive-400">${new Date(report.date).toLocaleDateString()}</span>
+                            <span class="shrink-0 text-[10px] font-bold uppercase ${failed ? 'text-red-500' : 'text-olive-400'}">${failed ? 'Failed' : new Date(report.date).toLocaleDateString()}</span>
                         </div>
+                        ${failed && report.error ? `<p class="mt-2 line-clamp-2 rounded-lg bg-red-50 p-2 font-mono text-[10px] text-red-700">${escapeHTML(report.error)}</p>` : ''}
                         <div class="mt-3 flex items-center justify-between gap-2">
-                            <span class="text-[10px] font-medium text-olive-500">${report.driveHtmlUrl || report.drivePdfUrl ? 'Drive synced' : 'Local only'}</span>
+                            <span class="text-[10px] font-medium ${failed ? 'text-red-600' : 'text-olive-500'}">${failed ? `Failed${report.duration ? ` after ${report.duration}s` : ''}` : (report.driveHtmlUrl || report.drivePdfUrl ? 'Drive synced' : 'Local only')}</span>
                             <div class="flex items-center gap-1.5">${actions}</div>
                         </div>
                     </div>

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -455,17 +455,17 @@ function updateHostRow(data) {
         row.id = `row-${data.ip.replace(/\./g, '-')}`;
         row.className = 'hover:bg-olive-50 transition-colors border-b border-olive-100';
         row.innerHTML = `
-            <td class="px-4 py-2 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
-            <td class="px-1.5 py-2 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
-            <td class="px-1.5 py-2 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
-            <td class="px-1.5 py-2 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
-            <td class="px-1.5 py-2 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
-            <td class="px-2 py-2 text-[10px] cve-cell">--</td>
-            <td class="px-4 py-2 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
-            <td class="px-4 py-2 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
-            <td class="px-4 py-2 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
-            <td class="px-4 py-2 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
-            <td class="px-4 py-2 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-3 py-1 rounded-full transition-all">DETAILS</button></td>
+            <td class="px-2 py-1 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
+            <td class="px-1 py-1 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
+            <td class="px-1 py-1 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
+            <td class="px-1 py-1 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
+            <td class="px-1 py-1 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
+            <td class="px-1 py-1 text-[10px] cve-cell">--</td>
+            <td class="px-2 py-1 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
+            <td class="px-2 py-1 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
+            <td class="px-2 py-1 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
+            <td class="px-2 py-1 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
+            <td class="px-2 py-1 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-1.5 py-0.5 rounded-full transition-all">DETAILS</button></td>
         `;
         tableBody.appendChild(row);
     }

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -345,6 +345,7 @@ function initializeScanRuntime(socket) {
                 const actions = [
                     reportActionLink({ href: report.url, title: 'Open HTML report', icon: 'file-code-2' }),
                     reportActionLink({ href: report.pdfUrl, title: 'Open PDF report', icon: 'file-text', disabled: !report.pdfUrl }),
+                    reportActionLink({ href: report.xmlUrl, title: 'Open XML report', icon: 'braces', disabled: !report.xmlUrl }),
                     reportActionLink({ href: report.pdfUrl, title: 'Download PDF', icon: 'download', download: true, disabled: !report.pdfUrl }),
                     reportActionLink({ href: report.driveHtmlUrl || report.drivePdfUrl, title: 'Open in Google Drive', icon: 'cloud', disabled: !(report.driveHtmlUrl || report.drivePdfUrl) })
                 ].join('');

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -455,17 +455,17 @@ function updateHostRow(data) {
         row.id = `row-${data.ip.replace(/\./g, '-')}`;
         row.className = 'hover:bg-olive-50 transition-colors border-b border-olive-100';
         row.innerHTML = `
-            <td class="px-1 py-0.5 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
-            <td class="px-0.5 py-0.5 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
-            <td class="px-0.5 py-0.5 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
-            <td class="px-0.5 py-0.5 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
-            <td class="px-0.5 py-0.5 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
-            <td class="px-0.5 py-0.5 text-[10px] cve-cell">--</td>
-            <td class="px-1 py-0.5 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
-            <td class="px-1 py-0.5 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
-            <td class="px-1 py-0.5 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
-            <td class="px-1 py-0.5 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
-            <td class="px-1 py-0.5 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-1 py-0.5 rounded-full transition-all">DETAILS</button></td>
+            <td class="px-0 py-0.5 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
+            <td class="px-0 py-0.5 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
+            <td class="px-0 py-0.5 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] cve-cell">--</td>
+            <td class="px-0 py-0.5 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
+            <td class="px-0 py-0.5 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
+            <td class="px-0 py-0.5 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-0 py-0.5 rounded-full transition-all">DETAILS</button></td>
         `;
         tableBody.appendChild(row);
     }

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -68,6 +68,17 @@ function renderCVELink(cveText) {
     return `<a href="https://nvd.nist.gov/vuln/detail/${encodeURIComponent(cveId)}" target="_blank" rel="noopener noreferrer" class="block text-red-700 underline decoration-red-300 underline-offset-2 hover:text-red-900">${safeText}</a>`;
 }
 
+function reportActionLink({ href, title, icon, download = false, disabled = false }) {
+    if (disabled || !href) {
+        return `<span title="${escapeHTML(title)}" class="inline-flex size-8 items-center justify-center rounded-lg border border-zinc-200 bg-zinc-50 text-zinc-400"><i data-lucide="${icon}" class="size-4"></i></span>`;
+    }
+    return `<a href="${escapeHTML(href)}" ${download ? 'download' : 'target="_blank" rel="noopener noreferrer"'} title="${escapeHTML(title)}" aria-label="${escapeHTML(title)}" class="inline-flex size-8 items-center justify-center rounded-lg border border-olive-200 bg-white text-olive-700 transition-colors hover:border-olive-300 hover:bg-olive-50 hover:text-olive-950"><i data-lucide="${icon}" class="size-4"></i></a>`;
+}
+
+function refreshLucideIcons() {
+    if (window.lucide?.createIcons) window.lucide.createIcons();
+}
+
 function getCVECountsFromRows() {
     return Array.from(document.querySelectorAll('#discovery-table tbody tr')).reduce((totals, row) => {
         totals.high += Number(row.dataset.highCveCount || 0);
@@ -251,18 +262,20 @@ function initializeScanRuntime(socket) {
     socket.on('report_ready', (data) => {
         const reportStatus = document.getElementById('report-status');
         if (reportStatus) {
-            const pdfActions = data.pdfUrl ? `
-                <a href="${data.pdfUrl}" target="_blank" class="px-4 py-2 bg-red-600 text-white text-xs font-bold rounded-lg hover:bg-red-700 transition-colors">VIEW PDF</a>
-                <a href="${data.pdfUrl}" download class="px-4 py-2 bg-white text-red-700 border border-red-200 text-xs font-bold rounded-lg hover:bg-red-50 transition-colors">DOWNLOAD PDF</a>
-            ` : '';
+            const actions = [
+                reportActionLink({ href: data.url, title: 'Open HTML report', icon: 'file-code-2' }),
+                reportActionLink({ href: data.pdfUrl, title: 'Open PDF report', icon: 'file-text', disabled: !data.pdfUrl }),
+                reportActionLink({ href: data.pdfUrl, title: 'Download PDF', icon: 'download', download: true, disabled: !data.pdfUrl }),
+                reportActionLink({ href: data.driveHtmlUrl || data.drivePdfUrl, title: 'Open in Google Drive', icon: 'cloud', disabled: !(data.driveHtmlUrl || data.drivePdfUrl) })
+            ].join('');
             reportStatus.classList.remove('hidden');
             document.getElementById('report-status-text').innerHTML = `
                 <div class="flex flex-wrap items-center gap-3">
-                    <span class="flex-1 text-emerald-900 font-medium">Report Ready: <strong>${data.name}</strong>${data.customerProfile ? `<span class="block text-xs text-emerald-700">${data.customerProfile.folderName}</span>` : ''}</span>
-                    <a href="${data.url}" target="_blank" class="px-4 py-2 bg-emerald-600 text-white text-xs font-bold rounded-lg hover:bg-emerald-700 transition-colors">VIEW HTML</a>
-                    ${pdfActions}
+                    <span class="min-w-0 flex-1 text-sm text-emerald-900 font-medium">Report Ready: <strong>${escapeHTML(data.name)}</strong>${data.customerProfile ? `<span class="block truncate text-xs text-emerald-700">${escapeHTML(data.customerProfile.folderName)}</span>` : ''}</span>
+                    <div class="flex items-center gap-1.5">${actions}</div>
                 </div>
             `;
+            refreshLucideIcons();
         }
         socket.emit('get_reports');
     });
@@ -323,25 +336,34 @@ function initializeScanRuntime(socket) {
                 reportsStatus.textContent = '';
                 reportsStatus.classList.add('hidden');
             }
-            reportsList.innerHTML = data.map(report => `
-                <div class="bg-white border border-olive-200 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow">
-                    <div class="flex justify-between items-center mb-4">
-                        <div class="size-10 bg-emerald-50 text-emerald-600 rounded-xl flex items-center justify-center">
-                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+            reportsList.innerHTML = data.map(report => {
+                const actions = [
+                    reportActionLink({ href: report.url, title: 'Open HTML report', icon: 'file-code-2' }),
+                    reportActionLink({ href: report.pdfUrl, title: 'Open PDF report', icon: 'file-text', disabled: !report.pdfUrl }),
+                    reportActionLink({ href: report.pdfUrl, title: 'Download PDF', icon: 'download', download: true, disabled: !report.pdfUrl }),
+                    reportActionLink({ href: report.driveHtmlUrl || report.drivePdfUrl, title: 'Open in Google Drive', icon: 'cloud', disabled: !(report.driveHtmlUrl || report.drivePdfUrl) })
+                ].join('');
+                return `
+                    <div class="bg-white border border-olive-200 rounded-lg p-3 shadow-sm transition-shadow hover:shadow-md">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="min-w-0">
+                                <h4 class="truncate text-sm font-bold text-olive-900" title="${escapeHTML(report.name)}">${escapeHTML(report.name)}</h4>
+                                <p class="mt-0.5 truncate font-mono text-[10px] text-olive-500" title="${escapeHTML(report.folder || '')}">${escapeHTML(report.folder || 'reports')}</p>
+                            </div>
+                            <span class="shrink-0 text-[10px] font-bold uppercase text-olive-400">${new Date(report.date).toLocaleDateString()}</span>
                         </div>
-                        <span class="text-[10px] font-bold text-olive-400 uppercase tracking-widest">${new Date(report.date).toLocaleDateString()}</span>
+                        <div class="mt-3 flex items-center justify-between gap-2">
+                            <span class="text-[10px] font-medium text-olive-500">${report.driveHtmlUrl || report.drivePdfUrl ? 'Drive synced' : 'Local only'}</span>
+                            <div class="flex items-center gap-1.5">${actions}</div>
+                        </div>
                     </div>
-                    <h4 class="text-olive-900 font-bold mb-1 truncate" title="${report.name}">${report.name}</h4>
-                    ${report.folder ? `<p class="mb-4 font-mono text-[10px] text-olive-500 truncate" title="${report.folder}">${report.folder}</p>` : '<div class="mb-4"></div>'}
-                    <div class="grid gap-2 sm:grid-cols-2">
-                        <a href="${report.url}" target="_blank" class="block text-center py-2 bg-emerald-50 text-emerald-700 text-xs font-bold rounded-xl hover:bg-emerald-100 transition-colors">VIEW HTML</a>
-                        ${report.pdfUrl ? `<a href="${report.pdfUrl}" target="_blank" class="block text-center py-2 bg-red-50 text-red-700 text-xs font-bold rounded-xl hover:bg-red-100 transition-colors">VIEW PDF</a>` : ''}
-                        ${report.pdfUrl ? `<a href="${report.pdfUrl}" download class="block text-center py-2 bg-white text-red-700 border border-red-200 text-xs font-bold rounded-xl hover:bg-red-50 transition-colors sm:col-span-2">DOWNLOAD PDF</a>` : `<span class="block text-center py-2 bg-zinc-50 text-zinc-500 text-xs font-bold rounded-xl sm:col-span-2">PDF NOT GENERATED</span>`}
-                    </div>
-                </div>
-            `).join('');
+                `;
+            }).join('');
+            refreshLucideIcons();
         }
     });
+
+    socket.on('reports_refresh', () => socket.emit('get_reports'));
 }
 
 function renderHop(data) {

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -136,6 +136,7 @@ function initializeScanRuntime(socket) {
             const versionEl = document.getElementById('app-version');
             if (versionEl) versionEl.textContent = state.version;
         }
+        if (state.customerProfile && typeof renderCustomerFingerprint === 'function') {
             renderCustomerFingerprint(state.customerProfile);
         }
 

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -462,8 +462,8 @@ function updateHostRow(data) {
         row.className = 'hover:bg-olive-50 transition-colors border-b border-olive-100';
         row.innerHTML = `
             <td class="px-0 py-0.5 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
-            <td class="px-0 py-0.5 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
-            <td class="px-0 py-0.5 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
+            <td class="px-1 py-0.5 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
+            <td class="px-1 py-0.5 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
             <td class="px-0 py-0.5 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
             <td class="px-0 py-0.5 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
             <td class="px-0 py-0.5 text-[10px] cve-cell">--</td>

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -526,7 +526,8 @@ function initializeDiscoveryUI(socket) {
     if (completeScanBtn) {
         completeScanBtn.addEventListener('click', () => {
             const target = document.getElementById('scan-target').value;
-            socket.emit('start_complete_scan', { target });
+            const vpnHelper = !!document.getElementById('vpn-helper-toggle')?.checked;
+            socket.emit('start_complete_scan', { target, vpnHelper });
         });
     }
     if (dragnetScanBtn) {

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -455,17 +455,17 @@ function updateHostRow(data) {
         row.id = `row-${data.ip.replace(/\./g, '-')}`;
         row.className = 'hover:bg-olive-50 transition-colors border-b border-olive-100';
         row.innerHTML = `
-            <td class="px-2 py-1 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
-            <td class="px-1 py-1 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
-            <td class="px-1 py-1 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
-            <td class="px-1 py-1 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
-            <td class="px-1 py-1 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
-            <td class="px-1 py-1 text-[10px] cve-cell">--</td>
-            <td class="px-2 py-1 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
-            <td class="px-2 py-1 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
-            <td class="px-2 py-1 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
-            <td class="px-2 py-1 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
-            <td class="px-2 py-1 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-1.5 py-0.5 rounded-full transition-all">DETAILS</button></td>
+            <td class="px-1 py-0.5 text-center"><span class="size-2 rounded-full bg-emerald-500 inline-block shadow-[0_0_8px_rgba(16,185,129,0.5)]"></span></td>
+            <td class="px-0.5 py-0.5 font-mono text-[11px] text-olive-900 ip-cell">${data.ip}</td>
+            <td class="px-0.5 py-0.5 font-mono text-[10px] text-olive-600 mac-cell">${data.mac || '--'}</td>
+            <td class="px-0.5 py-0.5 text-[10px] text-olive-700 truncate vendor-cell" title="${data.vendor || '--'}">${data.vendor || '--'}</td>
+            <td class="px-0.5 py-0.5 text-[10px] font-medium text-olive-900 truncate hostname-cell" title="${data.hostname || '--'}">${data.hostname || '--'}</td>
+            <td class="px-0.5 py-0.5 text-[10px] cve-cell">--</td>
+            <td class="px-1 py-0.5 text-[10px] text-olive-700 os-cell">${data.os || '--'}</td>
+            <td class="px-1 py-0.5 text-[10px] text-olive-700 latency-cell">${data.latency || '--'}</td>
+            <td class="px-1 py-0.5 text-[10px] text-olive-700 ports-cell">${data.ports || '--'}</td>
+            <td class="px-1 py-0.5 text-[10px] text-olive-700 version-cell">${data.version || '--'}</td>
+            <td class="px-1 py-0.5 text-right"><button class="text-[10px] font-bold text-olive-600 bg-olive-100 hover:bg-olive-200 px-1 py-0.5 rounded-full transition-all">DETAILS</button></td>
         `;
         tableBody.appendChild(row);
     }

--- a/static/js/settings_tab.js
+++ b/static/js/settings_tab.js
@@ -87,7 +87,7 @@ function renderGoogleDriveSummary({ config = {}, status = {} } = {}) {
         connectedState.textContent = status.connected ? 'Connected' : (status.configured ? 'Not connected' : 'Credentials missing');
         connectedState.className = status.connected ? 'font-semibold text-emerald-700' : 'font-semibold text-amber-700';
     }
-    if (folderState) folderState.textContent = folderId || 'Auto-create Gemini Nmap Reports';
+    if (folderState) folderState.textContent = folderId || 'Auto-create Nmap Reports';
 }
 
 function applyGoogleDriveConfig(config = {}, status = {}) {


### PR DESCRIPTION
## Summary
- Bring the tested `express-dev` runtime/install hardening onto a branch based on `main`
- Make report listing denser with compact Lucide icon actions
- Generate PDF exports in portrait orientation instead of landscape
- Persist Google Drive upload links beside reports and surface Drive actions in the reports UI
- Upload Google Drive report files into a day folder, e.g. `Nmap Reports/2026-05-02/`
- Archive local XML reports beside HTML/PDF output for future history comparison tooling
- Restart an existing TM-NMapUI listener on the target port instead of switching ports
- Tighten front-page discovery table padding and make the device table fit the report panel width
- Keep Complete+PDF fast by trying Phase 2 as one all-hosts Nmap command with vulners first
- Add an optional VPN Helper toggle for gentler Complete+PDF Phase 2 timing
- Record incomplete/NSE-crashed Nmap report runs as failed history/report entries with captured stderr so recurrence can be tracked
- Add a two-pass Phase 2 fallback recovery: 2.1 service/OS without scripts, then 2.2 vulners-only
- Run startup Homebrew maintenance for Nmap with `brew update && brew upgrade nmap` when Homebrew is available
- Preserve the current `main` cleanup changes, including `OLD_FILES.zip` removal and NmapUI Google Drive naming
- Keep this as a draft so it can be validated from a fresh clone before updating `main`

## Changes
- Make `install.sh` run from the repo directory and use `npm ci` when a lockfile exists
- Treat unavailable `wkhtmltopdf` as optional so npm dependencies still install
- Resolve `nmap`, `traceroute`, and `brew` from env vars and common macOS/Homebrew paths
- Run Homebrew Nmap maintenance at startup; when the app is launched with `sudo`, run brew as the original `SUDO_USER` instead of root
- Use `sudo -n` for Nmap and surface passwordless-sudo guidance
- Guard startup script updates when Nmap/sudo is unavailable
- Add `/api/app-identity` and a startup port guard that only terminates an existing listener when it identifies as TM-NMapUI
- Restore customer profile rendering during `sync_state`
- Populate and auto-select the dashboard customer profile dropdown from saved/current customer signals
- Reduce reports grid spacing/card padding and use compact icon buttons for HTML, PDF, XML, download, and Drive
- Add per-report Drive metadata files (`*.drive.json`) after successful uploads so report listings can show Drive links
- Copy each source Nmap XML into the report archive as `<report-base>.xml` and expose the XML URL in history/report metadata
- Create/find a dated Google Drive folder under the configured root folder before uploading report files
- Remove discovery table horizontal cell padding except `px-1` on IP and MAC, reduce fixed column widths, and use proportional table columns
- Restore Complete+PDF Phase 2 to all-hosts-at-once without `--min-hostgroup 1 --max-hostgroup 4`
- Change Phase 2 Nmap defaults to `-T3 --open --script vulners --script-args mincvss=0,threads=10`
- Add dashboard VPN Helper mode for Complete+PDF Phase 2: `-T2 --script-args mincvss=0,threads=5 --max-parallelism 15 --max-retries 2`
- If primary Phase 2 fails before complete XML is written, save a failed scan record with duration, host count, customer profile, and Nmap stderr; show that record in History and Reports
- After that recorded failure, automatically attempt fallback 2.1: `-sS -sV -O -Pn -T3 --open -oX phase2_no_script.xml -iL targets.tmp`
- If 2.1 succeeds, automatically attempt fallback 2.2: `-sV --script vulners --script-args threads=8 -iL targets.tmp -oX phase2_vulners.xml`
- Generate the fallback report from the 2.2 XML when recovery succeeds, while parsing 2.1 first so the live UI can retain service/OS details

## Validation
- `node --check server.js`
- `node --check static/js/scan_runtime.js`
- `node --check static/js/settings_tab.js`
- `python3 -m py_compile google_drive.py`
- `git diff --check`
- Local server smoke on `PORT=19001` returned HTTP 200 for `/`
- Port conflict smoke on `PORT=19002`: second start detected existing TM-NMapUI, stopped it, and restarted on the same port

## Test Instructions
```bash
git clone https://github.com/techmore/TM-NmapUI.git
cd TM-NmapUI
git switch codex/test-express-dev-hardening
./install.sh
sudo npm start
```