### PR TITLE
[codex] Keep report artifacts on one XML snapshot

### DIFF
--- a/server.js
+++ b/server.js
@@ -1107,8 +1107,10 @@ function generateReportFromXml(socket, xmlPath, duration, reportScanKind, onComp
     const reportUrl = `/reports/${profile.folderName}/${reportName}`;
     const pdfUrl = `/reports/${profile.folderName}/${pdfName}`;
     const xmlUrl = `/reports/${profile.folderName}/${xmlName}`;
+    let reportXmlPath = xmlPath;
     try {
         fs.copyFileSync(xmlPath, xmlArchivePath);
+        reportXmlPath = xmlArchivePath;
         logEvent(socket, 'report', `XML archived: ${xmlName}`);
     } catch (error) {
         logEvent(socket, 'error', `XML archive failed for ${xmlName}: ${error.message}`);
@@ -1132,7 +1134,7 @@ function generateReportFromXml(socket, xmlPath, duration, reportScanKind, onComp
             '--stringparam', 'cidr', shellQuote(networkInfo.cidr || ''),
             '--stringparam', 'traceroute_summary', shellQuote(tracerouteSummary),
             shellQuote(xslPath),
-            shellQuote(xmlPath)
+            shellQuote(reportXmlPath)
         ].join(' ');
         exec(xsltCommand, (err) => {
             if (!err) {


### PR DESCRIPTION
## What changed

- Generate HTML and PDF reports from the archived XML snapshot after it is copied successfully.
- Preserve the existing runtime XML fallback when the archive copy fails.

## Why

Screenshot capture is asynchronous. During that delay, another scan can overwrite the runtime XML file, causing the generated HTML/PDF to describe different scan data than the archived XML. Using the immutable archive as the XSLT input keeps all published report artifacts aligned.

## Impact

Report generation behavior and filenames are unchanged. The HTML, XML, and PDF outputs now consistently come from the same scan snapshot when XML archival succeeds.

## Validation

- `git diff --check`
- `node --check server.js`
- `xsltproc` transformation of `phase2_no_script.xml` with the production stylesheet and report parameters
