### PR TITLE
Fix dead scan buttons: frontend event aliases + runtime_store kwarg

### DIFF
--- a/nmapui/app_scan_runtime.py
+++ b/nmapui/app_scan_runtime.py
@@ -24,6 +24,7 @@ def start_scan_task(
     logger,
     settings_state,
     vulners_script,
+    runtime_store=None,
 ):
     return start_scan_task_impl(
         sid=sid,
@@ -31,6 +32,7 @@ def start_scan_task(
         broadcaster=broadcaster,
         emit_to_client=emit_to_client,
         get_client_state=get_client_state,
+        runtime_store=runtime_store,
         ensure_job_not_cancelled=ensure_job_not_cancelled,
         idle_state_manager=idle_state_manager,
         update_job_progress=update_job_progress,

--- a/nmapui/handlers/scan_jobs.py
+++ b/nmapui/handlers/scan_jobs.py
@@ -15,13 +15,16 @@ def register_scan_job_handlers(socketio, deps):
     generate_report_task = deps["generate_report_task"]
     generate_pdf_from_saved_task = deps.get("generate_pdf_from_saved_task")
 
-    @socketio.on("start_scan")
-    @require_socket_auth()
-    def start_scan(data):
+    def _start_scan_core(data, extra=None):
+        payload = dict(extra or {})
         if isinstance(data, dict):
-            target = data.get("target", "")
+            payload.update(data)
         else:
-            target = str(data) if data else ""
+            payload["target"] = str(data) if data else ""
+        target = payload.get("target", "")
+
+        if not isinstance(target, str):
+            target = str(target)
 
         is_valid, error_msg = validate_target(target)
         if not is_valid:
@@ -50,6 +53,27 @@ def register_scan_job_handlers(socketio, deps):
             rate_limiter.record_scan()
         emit_job_status(request.sid, "scan")
         socketio.start_background_task(start_scan_task, request.sid, target)
+
+    # Legacy event names emitted by the frontend buttons (quick/complete/dragnet).
+    @socketio.on("start_quick_scan")
+    @require_socket_auth()
+    def start_quick_scan(data):
+        _start_scan_core(data)
+
+    @socketio.on("start_complete_scan")
+    @require_socket_auth()
+    def start_complete_scan(data):
+        _start_scan_core(data)
+
+    @socketio.on("start_dragnet_scan")
+    @require_socket_auth()
+    def start_dragnet_scan(data):
+        _start_scan_core(data)
+
+    @socketio.on("start_scan")
+    @require_socket_auth()
+    def start_scan(data):
+        _start_scan_core(data)
 
     @socketio.on("generate_report")
     @require_socket_auth()


### PR DESCRIPTION
## Summary
Two functional bugs found during live end-to-end testing of the Flask webshell:

1. **Dead scan buttons**: the frontend emits `start_quick_scan` / `start_complete_scan` / `start_dragnet_scan`, but the Flask runtime only handled a generic `start_scan` event — so the Quick Scan, Complete+PDF, and Dragnet buttons silently did nothing on the primary webshell. Adds handlers for all three names, routed through a shared `_start_scan_core` (same validation/rate-limit/job-registry path as `start_scan`).

2. **Every scan crashed at launch**: `start_scan_task` rejected the `runtime_store` kwarg that `build_scan_task_deps` passes (`TypeError: got an unexpected keyword argument 'runtime_store'`). The wrapper now accepts and forwards it to the impl (which already supports it).

## Verification
Live headless test against a running server: UI click on Quick Scan with target 127.0.0.1/32 now runs `nmap -sn` + the vulners deep pass, detects CVEs (e.g. CVE-2024-47850 score 7.5), records the scan in history, and updates the discovery table (quick-hosts = 1).

No new test failures vs baseline (16 pre-existing).