### PR TITLE
PDF: collapse raw vulners dumps into CVE-table pointer (#167)

### DIFF
--- a/nmap-pdf-olive-legacy.xsl
+++ b/nmap-pdf-olive-legacy.xsl
@@ -1322,7 +1322,14 @@ Updated: 2026
                                   <xsl:for-each select="script">
                                     <div class="mb-3">
                                       <h5 class="font-semibold text-olive-800 mb-1"><xsl:value-of select="@id"/></h5>
-                                      <pre class="text-xs bg-white p-3 rounded border border-olive-200 overflow-x-auto"><xsl:value-of select="@output"/></pre>
+                                      <xsl:choose>
+                                        <xsl:when test="@id = 'vulners'">
+                                          <p class="text-xs text-olive-600 italic">CVE details for this service are listed in the CVE Findings table (page 1).</p>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                          <pre class="text-xs bg-white p-3 rounded border border-olive-200 overflow-x-auto"><xsl:value-of select="@output"/></pre>
+                                        </xsl:otherwise>
+                                      </xsl:choose>
                                     </div>
                                   </xsl:for-each>
                                 </td>


### PR DESCRIPTION
Final cleanup item from #167's v2 visual audit.

## Change
Per-port vulners script output (previously multi-page raw monospaced dumps) now renders as a one-line pointer to the CVE Findings table on page 1. The structured table added in #234 is the canonical presentation; other short script outputs render as before.

## Result
- PDF dropped from 7 pages to 5
- Page 2 visually verified: structured tables only, no raw dumps, clean flow

Refs #167