### PR TITLE
PDF: wrap long CPE strings, fix page-edge truncation (#167)

### DIFF
--- a/nmap-pdf-olive-legacy.xsl
+++ b/nmap-pdf-olive-legacy.xsl
@@ -142,6 +142,17 @@ Updated: 2026
             width: 100%;
           }
           
+          /* #167 v2: keep wide tables inside the page */
+          @media print {
+            html, body { width: 100% !important; }
+            .max-w-7xl { max-width: 100% !important; padding: 0 !important; }
+            table { table-layout: auto; }
+            th, td { font-size: 9px !important; padding: 3px 4px !important; }
+            td, th { word-break: break-word; overflow-wrap: anywhere; }
+            .font-mono, td.font-mono { word-break: break-all !important; }
+            nav.fixed { position: static !important; }
+          }
+
           .card {
             background: white;
             border: 1px solid #d8dbc7;


### PR DESCRIPTION
Last cosmetic item from the #167 v2 audit: long CPE strings were cut off at the right page edge.

## Change
Print-media CSS in nmap-pdf-olive-legacy.xsl:
- Constrain `max-w-7xl` content to full width for print
- Smaller table typography (9px) with tighter padding
- `word-break: break-all` on monospace cells so CPE identifiers wrap within their columns

## Verification
Visually inspected regenerated PDF (5 pages): `cpe:/a:openbsd:openssh:10.3` fully visible, wrapped within its column, no edge truncation. Layout and readability otherwise unchanged.

Refs #167