### PR TITLE
fix: zombie jobs + function collision killed Quick Scan clicks

### DIFF
--- a/nmapui/handlers/connections.py
+++ b/nmapui/handlers/connections.py
@@ -129,6 +129,13 @@ def register_connection_handlers(socketio, deps):
         if auto_scan_config is not None:
             emit_to_client(new_sid, "auto_scan_status", build_auto_scan_status_payload(auto_scan_config))
 
+        # #237: ignore zombie jobs whose owner tab has disconnected.
+        if owner_sid and owner_sid not in getattr(broadcaster, "_connected_sids", set()):
+            _complete = getattr(job_registry, "complete", None)
+            if callable(_complete):
+                _complete(owner_sid, active_job_type or "scan", status="completed")
+            broadcaster.end_job(owner_sid, job_type=active_job_type or "scan")
+            job = None
         job = job_registry.get(owner_sid, active_job_type) if owner_sid else None
         is_scanning = bool(job and job.get("status") in ("running", "cancelling"))
         last_scan_target = source_state.get("last_scan_target") or ""
@@ -197,6 +204,14 @@ def register_connection_handlers(socketio, deps):
         )
 
         job = job_registry.get(owner_sid, active_job_type) if owner_sid else None
+        # #237 follow-up: a job whose owner tab is gone is a zombie - it would
+        # otherwise disable scan buttons for every future page load.
+        if owner_sid and owner_sid not in getattr(broadcaster, "_connected_sids", set()):
+            job = None
+            _complete = getattr(job_registry, "complete", None)
+            if callable(_complete):
+                _complete(owner_sid, active_job_type or "scan", status="completed")
+            broadcaster.end_job(owner_sid, job_type=active_job_type or "scan")
         is_scanning = bool(job and job.get("status") in ("running", "cancelling"))
         last_scan_target = source_state.get("last_scan_target") or ""
         network_key = source_state.get("network_key") or {}

--- a/static/js/app_bootstrap.js
+++ b/static/js/app_bootstrap.js
@@ -57,6 +57,14 @@ async function bootstrapApp() {
     }
     // Request the legacy sync snapshot now that all listeners are wired (#230 bridge).
     socket.emit('get_initial_data');
+    // Transport-level reconnect = new server session; closures hold the dead socket.
+    // Reload to rebuild everything against the live session (#237 follow-up).
+    if (socket.io) {
+        socket.io.on('reconnect', () => { location.reload(); });
+    }
+    if (typeof initializeScanButtonWiring === 'function') {
+        initializeScanButtonWiring(socket);
+    }
     if (typeof initializeDiscoveryUI === 'function') {
         initializeDiscoveryUI(socket);
     }

--- a/static/js/scan_runtime.js
+++ b/static/js/scan_runtime.js
@@ -697,7 +697,7 @@ function updateHostRow(data) {
     updateCVESummaries();
 }
 
-function initializeDiscoveryUI(socket) {
+function initializeScanButtonWiring(socket) {
     const startScanBtn = document.getElementById('start-scan-btn');
     const completeScanBtn = document.getElementById('generate-report-btn');
     const dragnetScanBtn = document.getElementById('dragnet-scan-btn');

--- a/templates/index.html
+++ b/templates/index.html
@@ -1650,6 +1650,13 @@
             }
             // Request the legacy sync snapshot now that all listeners are wired (#230 bridge).
             socket.emit('get_initial_data');
+            // A transport-level reconnect creates a new server session; module
+            // closures still hold the dead socket, so events would vanish. Reload
+            // to rebuild everything against the live session (#237 follow-up).
+            socket.io.on('reconnect', () => { location.reload(); });
+            if (typeof initializeScanButtonWiring === 'function') {
+                initializeScanButtonWiring(socket);
+            }
             if (typeof initializeDiscoveryUI === 'function') {
                 initializeDiscoveryUI(socket);
             }


### PR DESCRIPTION
## Two stacked bugs made scans appear dead

### 1. Function name collision (root cause of silent clicks)
`scan_runtime.js` and `discovery_ui.js` **both** defined `initializeDiscoveryUI`. Load order meant discovery_ui's version overrode scan_runtime's — and the overridden version was the one that wired the Quick Scan button. The surviving click listener emitted on a stale socket reference, so clicks did nothing.

Fix: renamed scan_runtime's copy to `initializeScanButtonWiring`; both bootstraps now call it alongside discovery_ui's version.

### 2. Zombie jobs disabled all scan buttons
A page closed mid-scan left its job marked `running` forever. Every future page load then received `sync_state {isScanning: true}` from the connect bridge, disabling all scan buttons with no explanation.

Fix: connect/get_initial_data now verify the owner sid is still in `broadcaster._connected_sids` before reporting an active scan; disconnected owners' jobs are completed and torn down.

Also added: reload the page on socket.io transport reconnect (module closures hold the dead session's socket).

## Verified end-to-end
Click → quick scan → deep scan → **16 open ports + CVEs** rendered in the discovery table. Suite back to the 16 known-red baseline (309 passed).